### PR TITLE
[TCOE] Part 3: Optional Class Features

### DIFF
--- a/core/dungeon-masters-guide/classes/cleric-deathdomain.xml
+++ b/core/dungeon-masters-guide/classes/cleric-deathdomain.xml
@@ -4,7 +4,7 @@
 		<name>Death Domain</name>
 		<description>The Death Domain from the Dungeon Master’s Guide</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/dungeon-masters-guide">Wizards of the Coast</author>
-		<update version="0.1.2">
+		<update version="0.1.3">
 			<file name="cleric-deathdomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/dungeon-masters-guide/classes/cleric-deathdomain.xml" />
 		</update>
 	</info>
@@ -108,6 +108,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Dungeon Master’s Guide" id="ID_WOTC_DMG_ARCHETYPE_FEATURE_DEATH_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, the cleric gains the ability to infuse his or weapon strikes with necrotic energy. Once on each of the cleric's turns when he or she hits a creature with a weapon attack, the cleric can cause the attack to deal an extra 1d8 necrotic damage to the target. When the cleric reaches 14th level, the extra damage increases to 2d8.</p>
 		</description>

--- a/core/players-handbook/classes/class-cleric.xml
+++ b/core/players-handbook/classes/class-cleric.xml
@@ -1035,11 +1035,7 @@
 		</sheet>
 	</element>
 
-	<element name="Channel Divinity Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_CHANNEL_DIVINITY">
-		<compendium display="false" />
-	</element>
+	<element name="Channel Divinity Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_CHANNEL_DIVINITY" />
 
-	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
-		<compendium display="false" />
-	</element>
+	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING" />
 </elements>

--- a/core/players-handbook/classes/class-cleric.xml
+++ b/core/players-handbook/classes/class-cleric.xml
@@ -4,7 +4,7 @@
 		<name>Cleric</name>
 		<description>The Cleric class from the Player’s Handbook.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.4">
+		<update version="0.4.1">
 			<file name="class-cleric.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/classes/class-cleric.xml" />
 		</update>
 	</info>
@@ -361,6 +361,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_LIFE_DIVINESTRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 radiant damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>
@@ -508,6 +509,7 @@
 		</rules>
 	</element>
 	<element name="Potent Spellcasting" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_KNOWLEDGE_DOMAIN_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
 		</description>
@@ -613,6 +615,7 @@
 		</sheet>
 	</element>
 	<element name="Potent Spellcasting" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_LIGHT_DOMAIN_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
 		</description>
@@ -710,6 +713,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_NATURE_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 cold, fire, or lightning damage (your choice) to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>
@@ -814,6 +818,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_TEMPEST_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 thunder damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>
@@ -903,6 +908,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_TRICKERY_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with poison—a gift from your deity. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 poison damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>
@@ -1010,6 +1016,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_WAR_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 damage of the same type dealt by the weapon to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>

--- a/core/players-handbook/classes/class-cleric.xml
+++ b/core/players-handbook/classes/class-cleric.xml
@@ -1033,4 +1033,9 @@
 			<description>You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons.</description>
 		</sheet>
 	</element>
+
+	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
+		<compendium display="false" />
+	</element>
+
 </elements>

--- a/core/players-handbook/classes/class-cleric.xml
+++ b/core/players-handbook/classes/class-cleric.xml
@@ -198,6 +198,7 @@
 		</rules>
 	</element>
 	<element name="Channel Divinity" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_PHB_CLASS_FEATURE_CLERIC_CHANNELDIVINITY">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_CHANNEL_DIVINITY</requirements>
 		<description>
 			<p>At 2nd level, you gain the ability to channel divine energy directly from your deity, using that energy to fuel magical effects. You start with two such effects: Turn Undead and an effect determined by your domain. Some domains grant you additional effects as you advance in levels, as noted in the domain description.</p>
 			<p class="indent">When you use your Channel Divinity, you choose which effect to create. You must then finish a short or long rest to use your Channel Divinity again.</p>
@@ -1034,8 +1035,11 @@
 		</sheet>
 	</element>
 
-	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
+	<element name="Channel Divinity Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_CHANNEL_DIVINITY">
 		<compendium display="false" />
 	</element>
 
+	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
+		<compendium display="false" />
+	</element>
 </elements>

--- a/core/players-handbook/classes/class-ranger.xml
+++ b/core/players-handbook/classes/class-ranger.xml
@@ -4,7 +4,7 @@
 		<name>Ranger</name>
 		<description>The Ranger class from the Player’s Handbook.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.3.0">
+		<update version="0.3.1">
 			<file name="class-ranger.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/classes/class-ranger.xml" />
 		</update>
 	</info>
@@ -141,6 +141,7 @@
 		</multiclass>
 	</element>
 	<element name="Favored Enemy" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_FAVORED_ENEMY">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY</requirements>
 		<description>
 			<p>Beginning at 1st level, you have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.</p>
 			<p class="indent">Choose a type of favored enemy: aberrations, beasts, celestials, constructs, dragons, elementals, fey, fiends, giants, monstrosities, oozes, plants, or undead. Alternatively, you can select two races of humanoid (such as gnolls and orcs) as favored enemies.</p>
@@ -164,6 +165,7 @@
 		</rules>
 	</element>
 	<element name="Natural Explorer" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_NATURAL_EXPLORER">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER</requirements>
 		<description>
 			<p>You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions. Choose one type of favored terrain: arctic, coast, desert, forest, grassland, mountain, swamp, or the Underdark. When you make an Intelligence or Wisdom check related to your favored terrain, your proficiency bonus is doubled if you are using a skill that you’re proficient in.</p>
 			<p class="indent">While traveling for an hour or more in your favored terrain, you gain the following benefits:</p>
@@ -267,6 +269,7 @@
 		</rules>
 	</element>
 	<element name="Primeval Awareness" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_PRIMEVAL_AWARENESS">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS</requirements>
 		<description>
 			<p>Beginning at 3rd level, you can use your action and expend one ranger spell slot to focus your awareness on the region around you. For 1 minute per level of the spell slot you expend, you can sense whether the following types of creatures are present within 1 mile of you (or within up to 6 miles if you are in your favored terrain): aberrations, celestials, dragons, elementals, fey, fiends, and undead. This feature doesn’t reveal the creatures’ location or number.</p>
 		</description>
@@ -311,6 +314,7 @@
 		</sheet>
 	</element>
 	<element name="Hide in Plain Sight" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_CLASSFEATURE_RANGER_HIDE_IN_PLAIN_SIGHT">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT</requirements>
 		<description>
 			<p>Starting at 10th level, you can spend 1 minute creating camouflage for yourself. You must have access to fresh mud, dirt, plants, soot, and other naturally occurring materials with which to create your camouflage.</p>
 			<p class="indent">Once you are camouflaged in this way, you can try to hide by pressing yourself up against a solid surface, such as a tree or wall, that is at least as tall and wide as you are. You gain a +10 bonus to Dexterity (Stealth) checks as long as you remain there without moving or taking actions. Once you move or take an action or a reaction, you must camouflage yourself again to gain this benefit.</p>
@@ -967,6 +971,7 @@
 		</rules>
 	</element>
 	<element name="Ranger’s Companion" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_ARCHETYPEFEATURE_RANGER_RANGERS_COMPANION">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION</requirements>
 		<description>
 			<p>At 3rd level, you gain a beast companion that accompanies you on your adventures and is trained to fight alongside you. Choose a beast that is no larger than Medium and that has a challenge rating of 1/4 or lower (appendix D presents statistics for the hawk, mastiff, and panther as examples). Add your proficiency bonus to the beast’s AC, attack rolls, and damage rolls, as well as to any saving throws and skills it is proficient in. Its hit point maximum equals the hit point number in its stat block or four times your ranger level, whichever is higher. Like any creature, it can spend Hit Dice during a short rest to regain hit points.</p>
 			<p class="indent">The beast obeys your commands as best as it can. It takes its turn on your initiative. On your turn, you can verbally command the beast where to move (no action required by you). You can use your action to verbally command it to take the Attack, Dash, Disengage, or Help action. Once you have the Extra Attack feature, you can make one weapon attack yourself when you command the beast to take the Attack action. If you don’t issue a command, the beast takes the Dodge action.</p>

--- a/core/players-handbook/classes/class-ranger.xml
+++ b/core/players-handbook/classes/class-ranger.xml
@@ -1022,4 +1022,25 @@
 			<description>When you cast a spell targeting yourself, you can also affect your beast companion with the spell if the beast is within 30 feet of you.</description>
 		</sheet>
 	</element>
+
+	<element name="Natural Explorer Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER">
+		<compendium display="false" />
+	</element>
+
+	<element name="Favored Enemy Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY">
+		<compendium display="false" />
+	</element>
+
+	<element name="Primeval Awareness Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS">
+		<compendium display="false" />
+	</element>
+
+	<element name="Hide in Plain Sight Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT">
+		<compendium display="false" />
+	</element>
+
+	<element name="Ranger's Companion Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION">
+		<compendium display="false" />
+	</element>
+
 </elements>

--- a/core/players-handbook/classes/class-ranger.xml
+++ b/core/players-handbook/classes/class-ranger.xml
@@ -1023,24 +1023,14 @@
 		</sheet>
 	</element>
 
-	<element name="Natural Explorer Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER">
-		<compendium display="false" />
-	</element>
+	<element name="Natural Explorer Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER" />
 
-	<element name="Favored Enemy Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY">
-		<compendium display="false" />
-	</element>
+	<element name="Favored Enemy Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY" />
 
-	<element name="Primeval Awareness Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS">
-		<compendium display="false" />
-	</element>
+	<element name="Primeval Awareness Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS" />
 
-	<element name="Hide in Plain Sight Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT">
-		<compendium display="false" />
-	</element>
+	<element name="Hide in Plain Sight Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT" />
 
-	<element name="Ranger's Companion Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION">
-		<compendium display="false" />
-	</element>
+	<element name="Ranger's Companion Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION" />
 
 </elements>

--- a/supplements/guildmasters-guide-to-ravnica/archetypes/cleric-orderdomain.xml
+++ b/supplements/guildmasters-guide-to-ravnica/archetypes/cleric-orderdomain.xml
@@ -4,126 +4,127 @@
 		<name>Order Domain</name>
 		<description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/guildmasters-guide-ravnica">Guildmasters’ Guide to Ravnica</author>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="cleric-orderdomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/guildmasters-guide-to-ravnica/archetypes/cleric-orderdomain.xml" />
 		</update>
 	</info>
 	
-    <element name="Order Domain" type="Archetype" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_CLERIC_ORDER_DOMAIN">
-        <supports>Divine Domain</supports>
-        <description>
+	<element name="Order Domain" type="Archetype" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_CLERIC_ORDER_DOMAIN">
+		<supports>Divine Domain</supports>
+		<description>
 			<p>The Order Domain represents discipline, as well as devotion to a society or an institution and strict obedience to the laws governing it. On Ravnica, the domain is favored by clerics of the Azorius Senate, who use it to maintain and enforce the law, and of the Orzhov Syndicate, who exploit law and order for their personal gain. On other worlds, gods who grant access to this domain include Bane, Tyr, Majere, Erathis, Pholtus, Weejas, Aureon, Maglubiyet, Nuada, Athena, Anubis, Forseti, and Asmodeus.</p>
 			<p class="indent">The ideal of order is obedience to the law above all else, rather than to a specific individual or the passing influence of emotion or popular rule. Clerics of order are typically concerned with how things are done, rather than whether an action’s results are just. Following the law and obeying its edicts is critical, especially when it benefits these clerics and their guilds or deities.</p>
 			<p class="indent">Law establishes hierarchies. Those selected by the law to lead must be obeyed. Those who obey must do so to the best of their ability. In this manner, law creates an intricate web of obligations that allows society to forge order and security in a chaotic multiverse.</p>
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DOMAIN_SPELLS" />
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_BONUS_PROFICIENCIES" />
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_VOICE_OF_AUTHORITY" />
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_CD_ORDERS_DEMAND" />
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_EMBODIMENT_OF_THE_LAW" />
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE" />
-            <div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_ORDERS_WRATH" />
-        </description>
-        <sheet display="false">
-            <description>The Order Domain represents discipline, as well as devotion to a society or an institution and strict obedience to the laws governing it.</description>
-        </sheet>
-        <rules>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DOMAIN_SPELLS" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_VOICE_OF_AUTHORITY" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_CD_ORDERS_DEMAND" level="2"/>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_EMBODIMENT_OF_THE_LAW" level="6"/>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE" level="8"/>
-            <grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_ORDERS_WRATH" level="17"/>
-        </rules>
-    </element>
-    <element name="Domain Spells" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DOMAIN_SPELLS">
-        <description>
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_BONUS_PROFICIENCIES" />
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_VOICE_OF_AUTHORITY" />
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_CD_ORDERS_DEMAND" />
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_EMBODIMENT_OF_THE_LAW" />
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE" />
+			<div element="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_ORDERS_WRATH" />
+		</description>
+		<sheet display="false">
+			<description>The Order Domain represents discipline, as well as devotion to a society or an institution and strict obedience to the laws governing it.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_VOICE_OF_AUTHORITY" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_CD_ORDERS_DEMAND" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_EMBODIMENT_OF_THE_LAW" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_ORDERS_WRATH" level="17"/>
+		</rules>
+	</element>
+	<element name="Domain Spells" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DOMAIN_SPELLS">
+		<description>
 			<p>You gain domain spells at the cleric levels listed in the Order Domain Spells table. See the Divine Domain class feature in the Player’s Handbook for how domain spells work.</p>
-            <h5>Order Domain Spells</h5>
-            <table>
-                <thead>
-                    <tr><td>Cleric Level</td><td>Spells</td></tr>
-                </thead>
-                <tr><td>1st</td><td><em>command, heroism</em></td></tr>
-                <tr><td>3rd</td><td><em>hold person, zone of truth</em></td></tr>
-                <tr><td>5th</td><td><em>mass healing word, slow</em></td></tr>
-                <tr><td>7th</td><td><em>compulsion, locate creature</em></td></tr>
-                <tr><td>9th</td><td><em>commune, dominate person</em></td></tr>
-            </table>
-        </description>
-        <sheet display="false" />
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_COMMAND" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_HEROISM" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_HOLD_PERSON" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_ZONE_OF_TRUTH" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_MASS_HEALING_WORD" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_SLOW" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_COMPULSION" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_LOCATE_CREATURE" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_COMMUNE" level="9" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DOMINATE_PERSON" level="9" spellcasting="Cleric" prepared="true" />
-        </rules>
-    </element>
-    <element name="Bonus Proficiencies" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_BONUS_PROFICIENCIES">
-        <description>
+			<h5>Order Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>command, heroism</em></td></tr>
+				<tr><td>3rd</td><td><em>hold person, zone of truth</em></td></tr>
+				<tr><td>5th</td><td><em>mass healing word, slow</em></td></tr>
+				<tr><td>7th</td><td><em>compulsion, locate creature</em></td></tr>
+				<tr><td>9th</td><td><em>commune, dominate person</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_COMMAND" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_HEROISM" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_HOLD_PERSON" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_ZONE_OF_TRUTH" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_MASS_HEALING_WORD" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_SLOW" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_COMPULSION" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_LOCATE_CREATURE" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_COMMUNE" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DOMINATE_PERSON" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element>
+	<element name="Bonus Proficiencies" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_BONUS_PROFICIENCIES">
+		<description>
 			<p>When you choose this domain at 1st level, you gain proficiency with heavy armor. You also gain proficiency in the Intimidation or Persuasion skill (your choice).</p>
-        </description>
-        <sheet display="false">
-            <description>You gain proficiency with heavy armor. You also gain proficiency in the Intimidation or Persuasion skill.</description>
-        </sheet>
-        <rules>
-            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
+		</description>
+		<sheet display="false">
+			<description>You gain proficiency with heavy armor. You also gain proficiency in the Intimidation or Persuasion skill.</description>
+		</sheet>
+		<rules>
+			<grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
 			<select type="Proficiency" name="Bonus Skill Proficiency (Order Domain)" supports="ID_PROFICIENCY_SKILL_INTIMIDATION|ID_PROFICIENCY_SKILL_PERSUASION" />
-        </rules>
-    </element>
-    <element name="Voice of Authority" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_VOICE_OF_AUTHORITY">
-        <description>
+		</rules>
+	</element>
+	<element name="Voice of Authority" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_VOICE_OF_AUTHORITY">
+		<description>
 			<p>Starting at 1st level, you can invoke the power of law to drive an ally to attack. If you cast a spell with a spell slot of 1st level or higher and target an ally with the spell, that ally can use their reaction immediately after the spell to make one weapon attack against a creature of your choice that you can see.</p>
-            <p class="indent">If the spell targets more than one ally, you choose the ally who can make the attack.</p>
-        </description>
-        <sheet>
-            <description>If you cast a spell with a spell slot of 1st level or higher and target an ally with the spell, that ally can use their reaction immediately after the spell to make one weapon attack against a creature of your choice that you can see. If the spell targets more than one ally, you choose the ally who can make the attack.</description>
-        </sheet>
-    </element>
-    <element name="Channel Divinity: Order’s Demand" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_CD_ORDERS_DEMAND">
-        <description>
-            <p>Starting at 2nd level, you can use your Channel Divinity to exert an intimidating presence over others.</p>
+			<p class="indent">If the spell targets more than one ally, you choose the ally who can make the attack.</p>
+		</description>
+		<sheet>
+			<description>If you cast a spell with a spell slot of 1st level or higher and target an ally with the spell, that ally can use their reaction immediately after the spell to make one weapon attack against a creature of your choice that you can see. If the spell targets more than one ally, you choose the ally who can make the attack.</description>
+		</sheet>
+	</element>
+	<element name="Channel Divinity: Order’s Demand" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_CD_ORDERS_DEMAND">
+		<description>
+			<p>Starting at 2nd level, you can use your Channel Divinity to exert an intimidating presence over others.</p>
 			<p class="indent">As an action, you present your holy symbol, and each creature of your choice that can see or hear you within 30 feet of you must succeed on a Wisdom saving throw or be charmed by you until the end of your next turn or until the charmed creature takes any damage. You can also cause any of the charmed creatures to drop what they are holding when they fail the saving throw.</p>
-        </description>
-        <sheet alt="Order’s Demand" action="Action" usage="Channel Divinity">
-            <description>You present your holy symbol, and each creature of your choice that can see or hear you within 30 feet of you must succeed on a Wisdom saving throw or be charmed by you until the end of your next turn or until the charmed creature takes any damage. You can also cause any of the charmed creatures to drop what they are holding when they fail the saving throw.</description>
-        </sheet>
-    </element>	
-    <element name="Embodiment of the Law" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_EMBODIMENT_OF_THE_LAW">
-        <description>
+		</description>
+		<sheet alt="Order’s Demand" action="Action" usage="Channel Divinity">
+			<description>You present your holy symbol, and each creature of your choice that can see or hear you within 30 feet of you must succeed on a Wisdom saving throw or be charmed by you until the end of your next turn or until the charmed creature takes any damage. You can also cause any of the charmed creatures to drop what they are holding when they fail the saving throw.</description>
+		</sheet>
+	</element>	
+	<element name="Embodiment of the Law" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_EMBODIMENT_OF_THE_LAW">
+		<description>
 			<p>At 6th level, you become remarkably adept at channeling magical energy to compel others.</p>
 			<p class="indent">If you cast a spell of the enchantment school using a spell slot of 1st level or higher, you can change the spell's casting time to 1 bonus action for this casting, provided the spell's casting time is normally 1 action.</p>
 			<p class="indent">You can use this feature a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses of it when you finish a long rest.</p>
-        </description>
-        <sheet>
-            <description>If you cast a spell of the enchantment school using a spell slot of 1st level or higher, you can change the spell's casting time to 1 bonus action for this casting, provided the spell's casting time is normally 1 action. ({{embodiment of the law:usages}}/LR)</description>
-        </sheet>
+		</description>
+		<sheet>
+			<description>If you cast a spell of the enchantment school using a spell slot of 1st level or higher, you can change the spell's casting time to 1 bonus action for this casting, provided the spell's casting time is normally 1 action. ({{embodiment of the law:usages}}/LR)</description>
+		</sheet>
 		<rules>
 			<stat name="embodiment of the law:usages" value="1" bonus="embodiment of the law" />
 			<stat name="embodiment of the law:usages" value="wisdom:modifier" bonus="embodiment of the law" />
 		</rules>
-    </element>
-    <element name="Divine Strike" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE">
-        <description>
+	</element>
+	<element name="Divine Strike" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 psychic damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
-        </description>
-        <sheet>
-            <description>Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 psychic damage to the target.</description>
-            <description level="14">Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 psychic damage to the target.</description>
-        </sheet>
-    </element>
-    <element name="Order’s Wrath" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_ORDERS_WRATH">
-        <description>
+		</description>
+		<sheet>
+			<description>Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 psychic damage to the target.</description>
+			<description level="14">Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 psychic damage to the target.</description>
+		</sheet>
+	</element>
+	<element name="Order’s Wrath" type="Archetype Feature" source="Guildmasters’ Guide to Ravnica" id="ID_WOTC_GGTR_ARCHETYPE_FEATURE_ORDER_DOMAIN_ORDERS_WRATH">
+		<description>
 			<p>Starting at 17th level, enemies you designate for destruction wilt under the combined efforts of you and your allies. If you deal your Divine Strike damage to a creature on your turn, you can curse that creature until the start of your next turn. The next time one of your allies hits the cursed creature with an attack, the target also takes 2d8 psychic damage, and the curse ends. You can curse a creature in this way only once per turn.</p>
-        </description>
-        <sheet>
-            <description>If you deal your Divine Strike damage to a creature on your turn, you can curse that creature until the start of your next turn. The next time one of your allies hits the cursed creature with an attack, the target also takes 2d8 psychic damage, and the curse ends. You can curse a creature in this way only once per turn.</description>
-        </sheet>
-    </element>
+		</description>
+		<sheet>
+			<description>If you deal your Divine Strike damage to a creature on your turn, you can curse that creature until the start of your next turn. The next time one of your allies hits the cursed creature with an attack, the target also takes 2d8 psychic damage, and the curse ends. You can curse a creature in this way only once per turn.</description>
+		</sheet>
+	</element>
 </elements>

--- a/supplements/sword-coast-adventurers-guide/classes/cleric-arcanadomain.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/cleric-arcanadomain.xml
@@ -4,7 +4,7 @@
 		<name>Arcana Domain</name>
 		<description>Arcana Domain archetype from the Sword Coast Adventurer’s Guide.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/sc-adventurers-guide">Wizards of the Coast</author>
-		<update version="0.1.6">
+		<update version="0.1.7">
 			<file name="cleric-arcanadomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/sword-coast-adventurers-guide/classes/cleric-arcanadomain.xml" />
 		</update>
 	</info>
@@ -106,6 +106,7 @@
 		</sheet>
 	</element>
 	<element name="Potent Spellcasting" type="Archetype Feature" source="Sword Coast Adventurer’s Guide" id="ID_WOTC_SCAG_ARCHETYPE_FEATURE_ARCANA_DOMAIN_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
 		</description>

--- a/supplements/tashas-cauldron-of-everything/archetypes/cleric-order.xml
+++ b/supplements/tashas-cauldron-of-everything/archetypes/cleric-order.xml
@@ -4,7 +4,7 @@
 		<name>Order Domain</name>
 		<description>The Order Domain from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="cleric-order.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/archetypes/cleric-order.xml" />
 		</update>
 	</info>
@@ -123,6 +123,7 @@
 		</rules>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p><em>8th-level Order Domain feature</em></p>
 			<p>You gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 psychic damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>

--- a/supplements/tashas-cauldron-of-everything/archetypes/cleric-peace.xml
+++ b/supplements/tashas-cauldron-of-everything/archetypes/cleric-peace.xml
@@ -4,7 +4,7 @@
 		<name>Peace Doamin</name>
 		<description>The Peace Doamin from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="cleric-peace.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/archetypes/cleric-peace.xml" />
 		</update>
 	</info>
@@ -123,6 +123,7 @@
 		</rules>
 	</element>
 	<element name="Potent Spellcasting" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_PEACE_DOMAIN_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p><em>8th-level Peace Domain feature</em></p>
 			<p>You add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>

--- a/supplements/tashas-cauldron-of-everything/archetypes/cleric-twilight.xml
+++ b/supplements/tashas-cauldron-of-everything/archetypes/cleric-twilight.xml
@@ -4,7 +4,7 @@
 		<name>Twilight Domain</name>
 		<description>The Twilight Domain from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="cleric-twilight.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/archetypes/cleric-twilight.xml" />
 		</update>
 	</info>
@@ -142,6 +142,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_TWILIGHT_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p><em>8th-level Twilight Domain feature</em></p>
 			<p>You gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 radiant damage. When you reach 14th level, the extra damage increases to 2d8.</p>

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -350,10 +350,6 @@
 		</rules>
 	</element>
 
-	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
-		<compendium display="false" />
-	</element>
-
 	<!-- Druid -->
 	<!-- Additional Druid Spells -->
 	<element name="Additional Druid Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_ADDITIONAL_DRUID_SPELLS">
@@ -382,14 +378,14 @@
             <grant type="Spell" id="ID_PHB_SPELL_AUGURY" spellcasting="Druid" level="3" />
             <grant type="Spell" id="ID_PHB_SPELL_CONTINUAL_FLAME" spellcasting="Druid" level="3" />
             <grant type="Spell" id="ID_PHB_SPELL_ENLARGE_REDUCE" spellcasting="Druid" level="3" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SUMMON_BEAST" spellcasting="Druid" level="3" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_BEAST" spellcasting="Druid" level="3" />
             <grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Druid" level="5" />
             <grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" spellcasting="Druid" level="5" />
             <grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" spellcasting="Druid" level="5" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SUMMON_FEY" spellcasting="Druid" level="5" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_FEY" spellcasting="Druid" level="5" />
             <grant type="Spell" id="ID_PHB_SPELL_DIVINATION" spellcasting="Druid" level="7" />
             <grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" spellcasting="Druid" level="7" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SUMMON_ELEMENTAL" spellcasting="Druid" level="7" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL" spellcasting="Druid" level="7" />
             <grant type="Spell" id="ID_PHB_SPELL_CONE_OF_COLD" spellcasting="Druid" level="9" />
             <grant type="Spell" id="ID_PHB_SPELL_FLESH_TO_STONE" spellcasting="Druid" level="11" />
             <grant type="Spell" id="ID_PHB_SPELL_SYMBOL" spellcasting="Druid" level="13" />
@@ -872,10 +868,6 @@
 		</rules>
 	</element>
 
-	<element name="Natural Explorer Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER">
-		<compendium display="false" />
-	</element>
-
 	<element name="Canny" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_CANNY">
 		<description>
 			<p>Choose one of your skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses the chosen skill.</p>
@@ -952,10 +944,6 @@
 			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY" />
 			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_FAVORED_FOE" requirements="[level:ranger:1]"/>
 		</rules>
-	</element>
-
-	<element name="Favored Enemy Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY">
-		<compendium display="false" />
 	</element>
 
 	<!-- Additional Ranger Spells -->
@@ -1093,10 +1081,6 @@
 		</rules>
 	</element>
 
-	<element name="Primeval Awareness Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS">
-		<compendium display="false" />
-	</element>
-
 	<!-- Martial Versatility -->
 	<element name="Martial Versatility (Ranger)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_MARTIAL_VERSATILITY">
 		<description>
@@ -1159,10 +1143,6 @@
 		</rules>
 	</element>
 
-	<element name="Hide in Plain Sight Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT">
-		<compendium display="false" />
-	</element>
-
 	<!-- Beast Master Companions: Primal Companion -->
 	<element name="Primal Companion" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION">
 		<description>
@@ -1201,10 +1181,6 @@
 			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION" />
 			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION" requirements="ID_WOTC_ARCHETYPE_RANGER_BEAST_MASTER"/>
 		</rules>
-	</element>
-
-	<element name="Ranger's Companion Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION">
-		<compendium display="false" />
 	</element>
 
 	<!-- Beast Master Companions -->

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -223,16 +223,16 @@
 		<sheet display="false">
 			<description>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
-		<rules>
-			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Cleric" requirements="[level:cleric:5]"/>
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Cleric" requirements="[level:cleric:5]" />
-			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_LIFE" spellcasting="Cleric" requirements="[level:cleric:7]" />
-			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_PURITY" spellcasting="Cleric" requirements="[level:cleric:7]" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Cleric" requirements="[level:cleric:9]" />
-			<grant type="Spell" id="ID_PHB_SPELL_SUNBEAM" spellcasting="Cleric" requirements="[level:cleric:11]" />
-			<grant type="Spell" id="ID_PHB_SPELL_SUNBURST" spellcasting="Cleric" requirements="[level:cleric:15]" />
-			<grant type="Spell" id="ID_PHB_SPELL_POWER_WORD_HEAL" spellcasting="Cleric" requirements="[level:cleric:17]" />
-		</rules>
+		<spellcasting name="Cleric" extend="true">
+			<extend>ID_PHB_SPELL_AURA_OF_VITALITY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD</extend>
+			<extend>ID_PHB_SPELL_AURA_OF_LIFE</extend>
+			<extend>ID_PHB_SPELL_AURA_OF_PURITY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL</extend>
+			<extend>ID_PHB_SPELL_SUNBEAM</extend>
+			<extend>ID_PHB_SPELL_SUNBURST</extend>
+			<extend>ID_PHB_SPELL_POWER_WORD_HEAL</extend>
+		</spellcasting>
 	</element>
 
 	<element name="Cleric, LV01: Additional Cleric Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_ADDITIONAL_CLERIC_SPELLS">
@@ -296,7 +296,7 @@
 			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the cleric spell list.</p>
 		</description>
 		<sheet alt="Cantrip Versatility">
-			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the cleric spell list.</description>
+			<description>Whenever you reach a level in Cleric class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from Cleric's Spellcasting feature with another cantrip from the cleric spell list.</description>
 		</sheet>
 	</element>
 
@@ -373,24 +373,24 @@
 		<sheet display="false">
 			<description>The spells in the following list expand the druid spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" spellcasting="Druid" requirements="[level:druid:1]"/>
-            <grant type="Spell" id="ID_PHB_SPELL_AUGURY" spellcasting="Druid" requirements="[level:druid:3]" />
-            <grant type="Spell" id="ID_PHB_SPELL_CONTINUAL_FLAME" spellcasting="Druid" requirements="[level:druid:3]" />
-            <grant type="Spell" id="ID_PHB_SPELL_ENLARGE_REDUCE" spellcasting="Druid" requirements="[level:druid:3]" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_BEAST" spellcasting="Druid" requirements="[level:druid:3]" />
-            <grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Druid" requirements="[level:druid:5]" />
-            <grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" spellcasting="Druid" requirements="[level:druid:5]" />
-            <grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" spellcasting="Druid" requirements="[level:druid:5]" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_FEY" spellcasting="Druid" requirements="[level:druid:5]" />
-            <grant type="Spell" id="ID_PHB_SPELL_DIVINATION" spellcasting="Druid" requirements="[level:druid:7]" />
-            <grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" spellcasting="Druid" requirements="[level:druid:7]" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL" spellcasting="Druid" requirements="[level:druid:7]" />
-            <grant type="Spell" id="ID_PHB_SPELL_CONE_OF_COLD" spellcasting="Druid" requirements="[level:druid:9]" />
-            <grant type="Spell" id="ID_PHB_SPELL_FLESH_TO_STONE" spellcasting="Druid" requirements="[level:druid:11]" />
-            <grant type="Spell" id="ID_PHB_SPELL_SYMBOL" spellcasting="Druid" requirements="[level:druid:13]" />
-            <grant type="Spell" id="ID_PHB_SPELL_INCENDIARY_CLOUD" spellcasting="Druid" requirements="[level:druid:15]" />
-        </rules>
+		<spellcasting name="Druid" extend="true">
+			<extend>ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD</extend>
+			<extend>ID_PHB_SPELL_AUGURY</extend>
+			<extend>ID_PHB_SPELL_CONTINUAL_FLAME</extend>
+			<extend>ID_PHB_SPELL_ENLARGE_REDUCE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_BEAST</extend>
+			<extend>ID_PHB_SPELL_AURA_OF_VITALITY</extend>
+			<extend>ID_PHB_SPELL_ELEMENTAL_WEAPON</extend>
+			<extend>ID_PHB_SPELL_REVIVIFY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FEY</extend>
+			<extend>ID_PHB_SPELL_DIVINATION</extend>
+			<extend>ID_PHB_SPELL_FIRE_SHIELD</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL</extend>
+			<extend>ID_PHB_SPELL_CONE_OF_COLD</extend>
+			<extend>ID_PHB_SPELL_FLESH_TO_STONE</extend>
+			<extend>ID_PHB_SPELL_SYMBOL</extend>
+			<extend>ID_PHB_SPELL_INCENDIARY_CLOUD</extend>
+		</spellcasting>
 	</element>
 
 	<element name="Druid, LV01: Additional Druid Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_ADDITIONAL_DRUID_SPELLS">
@@ -450,7 +450,7 @@
 			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the druid spell list.</p>
 		</description>
 		<sheet alt="Cantrip Versatility">
-			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the druid spell list.</description>
+			<description>Whenever you reach a level in Druid class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from Druid's Spellcasting feature with another cantrip from the druid spell list.</description>
 		</sheet>
 	</element>
 
@@ -484,8 +484,8 @@
 				<li>If you know any maneuvers from the Battle Master archetype, you can replace one maneuver you know with a different maneuver.</li>
 			</ul>
 		</description>
-		<sheet>
-			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following: &#13;
+		<sheet alt="Martial Versatility">
+			<description>Whenever you reach a level in Fighter class that grants the Ability Score Improvement feature, you can do one of the following: &#13;
 			• Replace a fighting style you know with another fighting style available to fighters. &#13;
 			• If you know any maneuvers from the Battle Master archetype, you can replace one maneuver you know with a different maneuver.</description>
 		</sheet>
@@ -730,13 +730,13 @@
 		<sheet display="false">
 			<description>The spells in the following list expand the paladin spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_GENTLE_REPOSE" spellcasting="Paladin" requirements="[level:paladin:5]" />
-            <grant type="Spell" id="ID_PHB_SPELL_PRAYER_OF_HEALING" spellcasting="Paladin" requirements="[level:paladin:5]" />
-            <grant type="Spell" id="ID_PHB_SPELL_WARDING_BOND" spellcasting="Paladin" requirements="[level:paladin:5]" />
-            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Paladin" requirements="[level:paladin:9]" />
-            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Paladin" requirements="[level:paladin:17]" />
-        </rules>
+		<spellcasting name="Paladin" extend="true">
+			<extend>ID_PHB_SPELL_GENTLE_REPOSE</extend>
+			<extend>ID_PHB_SPELL_PRAYER_OF_HEALING</extend>
+			<extend>ID_PHB_SPELL_WARDING_BOND</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL</extend>
+		</spellcasting>
 	</element>
 
 	<element name="Paladin, LV02: Additional Paladin Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_ADDITIONAL_PALADIN_SPELLS">
@@ -800,7 +800,7 @@
 			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to paladins. This replacement represents a shift of focus in your martial practice.</p>
 		</description>
 		<sheet alt="Martial Versatility">
-			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to paladins.</description>
+			<description>Whenever you reach a level in Paladin class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to paladins.</description>
 		</sheet>
 	</element>
 
@@ -1088,7 +1088,7 @@
 			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to rangers. This replacement represents a shift of focus in your martial practice.</p>
 		</description>
 		<sheet alt="Martial Versatility">
-			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to rangers.</description>
+			<description>Whenever you reach a level in Ranger class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to rangers.</description>
 		</sheet>
 	</element>
 
@@ -1519,14 +1519,14 @@
 			<extend>ID_PHB_SPELL_MAGIC_WEAPON</extend>
 			<extend>ID_WOTC_TCOE_SPELL_TASHAS_MIND_WHIP</extend>
 			<extend>ID_WOTC_TCOE_SPELL_INTELLECT_FORTRESS</extend>
-            <extend>ID_PHB_SPELL_VAMPIRIC_TOUCH</extend>
+			<extend>ID_PHB_SPELL_VAMPIRIC_TOUCH</extend>
 			<extend>ID_PHB_SPELL_FIRE_SHIELD</extend>
 			<extend>ID_PHB_SPELL_BIGBYS_HAND</extend>
-            <extend>ID_PHB_SPELL_FLESH_TO_STONE</extend>
-            <extend>ID_PHB_SPELL_OTILUKES_FREEZING_SPHERE</extend>
+			<extend>ID_PHB_SPELL_FLESH_TO_STONE</extend>
+			<extend>ID_PHB_SPELL_OTILUKES_FREEZING_SPHERE</extend>
 			<extend>ID_WOTC_TCOE_SPELL_TASHAS_OTHERWORLDLY_GUISE</extend>
 			<extend>ID_WOTC_TCOE_SPELL_DREAM_OF_THE_BLUE_VEIL</extend>
-            <extend>ID_PHB_SPELL_DEMIPLANE</extend>
+			<extend>ID_PHB_SPELL_DEMIPLANE</extend>
 			<extend>ID_WOTC_TCOE_SPELL_BLADE_OF_DISASTER</extend>
 		</spellcasting>
 	</element>
@@ -1675,7 +1675,7 @@
 			<extend>ID_WOTC_TCOE_SPELL_SUMMON_ABERRATION</extend>
 			<extend>ID_PHB_SPELL_MISLEAD</extend>
 			<extend>ID_PHB_SPELL_PLANAR_BINDING</extend>
-            <extend>ID_PHB_SPELL_TELEPORTATION_CIRCLE</extend>
+			<extend>ID_PHB_SPELL_TELEPORTATION_CIRCLE</extend>
 			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FIEND</extend>
 			<extend>ID_WOTC_TCOE_SPELL_TASHAS_OTHERWORLDLY_GUISE</extend>
 			<extend>ID_WOTC_TCOE_SPELL_DREAM_OF_THE_BLUE_VEIL</extend>

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -224,14 +224,14 @@
 			<description>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
 		<rules>
-			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Cleric" level="5" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Cleric" level="5" />
-			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_LIFE" spellcasting="Cleric" level="7" />
-			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_PURITY" spellcasting="Cleric" level="7" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Cleric" level="9" />
-			<grant type="Spell" id="ID_PHB_SPELL_SUNBEAM" spellcasting="Cleric" level="11" />
-			<grant type="Spell" id="ID_PHB_SPELL_SUNBURST" spellcasting="Cleric" level="15" />
-			<grant type="Spell" id="ID_PHB_SPELL_POWER_WORD_HEAL" spellcasting="Cleric" level="17" />
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Cleric" requirements="[level:cleric:5]"/>
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Cleric" requirements="[level:cleric:5]" />
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_LIFE" spellcasting="Cleric" requirements="[level:cleric:7]" />
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_PURITY" spellcasting="Cleric" requirements="[level:cleric:7]" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Cleric" requirements="[level:cleric:9]" />
+			<grant type="Spell" id="ID_PHB_SPELL_SUNBEAM" spellcasting="Cleric" requirements="[level:cleric:11]" />
+			<grant type="Spell" id="ID_PHB_SPELL_SUNBURST" spellcasting="Cleric" requirements="[level:cleric:15]" />
+			<grant type="Spell" id="ID_PHB_SPELL_POWER_WORD_HEAL" spellcasting="Cleric" requirements="[level:cleric:17]" />
 		</rules>
 	</element>
 
@@ -374,22 +374,22 @@
 			<description>The spells in the following list expand the druid spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" spellcasting="Druid"/>
-            <grant type="Spell" id="ID_PHB_SPELL_AUGURY" spellcasting="Druid" level="3" />
-            <grant type="Spell" id="ID_PHB_SPELL_CONTINUAL_FLAME" spellcasting="Druid" level="3" />
-            <grant type="Spell" id="ID_PHB_SPELL_ENLARGE_REDUCE" spellcasting="Druid" level="3" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_BEAST" spellcasting="Druid" level="3" />
-            <grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Druid" level="5" />
-            <grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" spellcasting="Druid" level="5" />
-            <grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" spellcasting="Druid" level="5" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_FEY" spellcasting="Druid" level="5" />
-            <grant type="Spell" id="ID_PHB_SPELL_DIVINATION" spellcasting="Druid" level="7" />
-            <grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" spellcasting="Druid" level="7" />
-			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL" spellcasting="Druid" level="7" />
-            <grant type="Spell" id="ID_PHB_SPELL_CONE_OF_COLD" spellcasting="Druid" level="9" />
-            <grant type="Spell" id="ID_PHB_SPELL_FLESH_TO_STONE" spellcasting="Druid" level="11" />
-            <grant type="Spell" id="ID_PHB_SPELL_SYMBOL" spellcasting="Druid" level="13" />
-            <grant type="Spell" id="ID_PHB_SPELL_INCENDIARY_CLOUD" spellcasting="Druid" level="15" />
+            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" spellcasting="Druid" requirements="[level:druid:1]"/>
+            <grant type="Spell" id="ID_PHB_SPELL_AUGURY" spellcasting="Druid" requirements="[level:druid:3]" />
+            <grant type="Spell" id="ID_PHB_SPELL_CONTINUAL_FLAME" spellcasting="Druid" requirements="[level:druid:3]" />
+            <grant type="Spell" id="ID_PHB_SPELL_ENLARGE_REDUCE" spellcasting="Druid" requirements="[level:druid:3]" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_BEAST" spellcasting="Druid" requirements="[level:druid:3]" />
+            <grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Druid" requirements="[level:druid:5]" />
+            <grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" spellcasting="Druid" requirements="[level:druid:5]" />
+            <grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" spellcasting="Druid" requirements="[level:druid:5]" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_FEY" spellcasting="Druid" requirements="[level:druid:5]" />
+            <grant type="Spell" id="ID_PHB_SPELL_DIVINATION" spellcasting="Druid" requirements="[level:druid:7]" />
+            <grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" spellcasting="Druid" requirements="[level:druid:7]" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL" spellcasting="Druid" requirements="[level:druid:7]" />
+            <grant type="Spell" id="ID_PHB_SPELL_CONE_OF_COLD" spellcasting="Druid" requirements="[level:druid:9]" />
+            <grant type="Spell" id="ID_PHB_SPELL_FLESH_TO_STONE" spellcasting="Druid" requirements="[level:druid:11]" />
+            <grant type="Spell" id="ID_PHB_SPELL_SYMBOL" spellcasting="Druid" requirements="[level:druid:13]" />
+            <grant type="Spell" id="ID_PHB_SPELL_INCENDIARY_CLOUD" spellcasting="Druid" requirements="[level:druid:15]" />
         </rules>
 	</element>
 
@@ -731,11 +731,11 @@
 			<description>The spells in the following list expand the paladin spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_GENTLE_REPOSE" spellcasting="Paladin" level="5" />
-            <grant type="Spell" id="ID_PHB_SPELL_PRAYER_OF_HEALING" spellcasting="Paladin" level="5" />
-            <grant type="Spell" id="ID_PHB_SPELL_WARDING_BOND" spellcasting="Paladin" level="5" />
-            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Paladin" level="9" />
-            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Paladin" level="17" />
+            <grant type="Spell" id="ID_PHB_SPELL_GENTLE_REPOSE" spellcasting="Paladin" requirements="[level:paladin:5]" />
+            <grant type="Spell" id="ID_PHB_SPELL_PRAYER_OF_HEALING" spellcasting="Paladin" requirements="[level:paladin:5]" />
+            <grant type="Spell" id="ID_PHB_SPELL_WARDING_BOND" spellcasting="Paladin" requirements="[level:paladin:5]" />
+            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Paladin" requirements="[level:paladin:9]" />
+            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Paladin" requirements="[level:paladin:17]" />
         </rules>
 	</element>
 
@@ -1053,11 +1053,11 @@
 			<description>You can focus your awareness through the interconnections of nature: you learn additional spells when you reach certain levels in this class if you don't already know them, as shown in the Primal Awareness Spells table. These spells don't count against the number of ranger spells you know.</description>
 		</sheet>
 		<rules>
-			<grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_ANIMALS" spellcasting="Ranger" level="3" />
-			<grant type="Spell" id="ID_PHB_SPELL_BEAST_SENSE" spellcasting="Ranger" level="5" />
-			<grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_PLANTS" spellcasting="Ranger" level="9" />
-			<grant type="Spell" id="ID_PHB_SPELL_LOCATE_CREATURE" spellcasting="Ranger" level="13" />
-			<grant type="Spell" id="ID_PHB_SPELL_COMMUNE_WITH_NATURE" spellcasting="Ranger" level="17" />
+			<grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_ANIMALS" spellcasting="Ranger" requirements="[level:ranger:3]" />
+			<grant type="Spell" id="ID_PHB_SPELL_BEAST_SENSE" spellcasting="Ranger" requirements="[level:ranger:5]" />
+			<grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_PLANTS" spellcasting="Ranger" requirements="[level:ranger:9]" />
+			<grant type="Spell" id="ID_PHB_SPELL_LOCATE_CREATURE" spellcasting="Ranger" requirements="[level:ranger:13]" />
+			<grant type="Spell" id="ID_PHB_SPELL_COMMUNE_WITH_NATURE" spellcasting="Ranger" requirements="[level:ranger:17]" />
 		</rules>
 	</element>
 

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -9,26 +9,219 @@
 		</update>
 	</info>
 
+	<!-- Barbarian -->
+	<!-- Primal Knowledge -->
+	<element name="Primal Knowledge" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_BARBARIAN_PRIMAL_KNOWLEDGE">
+		<description>
+			<p><i>3rd-level barbarian feature</i></p>
+			<p>When you reach 3rd level and again at 10th level, you gain proficiency in one skill of your choice from the list of skills available to barbarians at 1st level.</p>
+		</description>
+		<sheet display="false">
+			<description>When you reach 3rd level and again at 10th level, you gain proficiency in one skill of your choice from the list of skills available to barbarians at 1st level.</description>
+		</sheet>
+		<rules>
+			<select type="Proficiency" name="Skill Proficiency (Primal Knowledge)" supports="Skill,Barbarian" />
+			<select type="Proficiency" name="Skill Proficiency (Primal Knowledge)" supports="Skill,Barbarian" requirements="[level:barbarian:10]"/>
+		</rules>
+	</element>
+
+	<element name="Optional Class Feature: Primal Knowledge" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARBARIAN_PRIMAL_KNOWLEDGE">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_BARBARIAN_PRIMAL_KNOWLEDGE" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Barbarian, third level, 3rd level, Skill Proficiency</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_BARBARIAN_PRIMAL_KNOWLEDGE" requirements="[level:barbarian:3]"/>
+		</rules>
+	</element>
+
+	<!-- Instinctive Pounce -->
+	<element name="Instinctive Pounce" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_BARBARIAN_INSTINCTIVE_POUNCE">
+		<description>
+			<p><i>7th-level barbarian feature</i></p>
+			<p>As part of the bonus action you take to enter your rage, you can move up to half your speed.</p>
+		</description>
+		<sheet>
+			<description>As part of the bonus action you take to enter your rage, you can move up to half your speed.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Instinctive Pounce" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARBARIAN_INSTINCTIVE_POUNCE">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_BARBARIAN_INSTINCTIVE_POUNCE" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Barbarian, seventh level, 7th level, rage, speed</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_BARBARIAN_INSTINCTIVE_POUNCE" requirements="[level:barbarian:7]"/>
+		</rules>
+	</element>
+
+	<!-- Bard -->
+	<!-- Additional Bard Spells -->
+	<element name="Additional Bard Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_BARD_ADDITIONAL_BARD_SPELLS">
+		<description>
+			<p><i>1st-level bard feature</i></p>
+			<p>The spells in the following list expand the bard spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>Color spray, Command</em></td></tr>
+				<tr><td>2nd</td><td><em>Aid, Enlarge/reduce, Mirror image</em></td></tr>
+				<tr><td>3rd</td><td><em>Intellect fortress*, Mass healing word, Slow</em></td></tr>
+				<tr><td>4th</td><td><em>Phantasmal killer</em></td></tr>
+				<tr><td>5th</td><td><em>Rary's telepathic bond (ritual)</em></td></tr>
+				<tr><td>6th</td><td><em>Heroes' feast</em></td></tr>
+				<tr><td>7th</td><td><em>Dream of the blue veil*, Prismatic spray</em></td></tr>
+				<tr><td>8th</td><td><em>Antipathy/sympathy</em></td></tr>
+				<tr><td>9th</td><td><em>Prismatic wall</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the bard spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+		<spellcasting name="Bard" extend="true">
+			<extend>ID_PHB_SPELL_COLOR_SPRAY</extend>
+			<extend>ID_PHB_SPELL_COMMAND</extend>
+			<extend>ID_PHB_SPELL_AID</extend>
+			<extend>ID_PHB_SPELL_ENLARGE_REDUCE</extend>
+			<extend>ID_PHB_SPELL_MIRROR_IMAGE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_INTELLECT_FORTRESS</extend>
+			<extend>ID_PHB_SPELL_MASS_HEALING_WORD</extend>
+			<extend>ID_PHB_SPELL_SLOW</extend>
+			<extend>ID_PHB_SPELL_PHANTASMAL_KILLER</extend>
+			<extend>ID_PHB_SPELL_RARYS_TELEPATHIC_BOND</extend>
+			<extend>ID_PHB_SPELL_HEROES_FEAST</extend>
+			<extend>ID_WOTC_TCOE_SPELL_DREAM_OF_THE_BLUE_VEIL</extend>
+			<extend>ID_PHB_SPELL_PRISMATIC_SPRAY</extend>
+			<extend>ID_PHB_SPELL_ANTIPATHY_SYMPATHY</extend>
+			<extend>ID_PHB_SPELL_PRISMATIC_WALL</extend>
+		</spellcasting>
+	</element>
+
+	<element name="Optional Class Feature: Additional Bard Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_ADDITIONAL_BARD_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_BARD_ADDITIONAL_BARD_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Bard, first level, 1st level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_BARD_ADDITIONAL_BARD_SPELLS" requirements="[level:bard:1]"/>
+		</rules>
+	</element>
+
+	<!-- Magical Inspiration -->
+	<element name="Magical Inspiration" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_BARD_MAGICAL_INSPIRATION">
+		<description>
+			<p><i>2nd-level bard feature</i></p>
+			<p>If a creature has a Bardic Inspiration die from you and casts a spell that restores hit points or deals damage, the creature can roll that die and choose a target affected by the spell. Add the number rolled as a bonus to the hit points regained or the damage dealt. The Bardic Inspiration die is then lost.</p>
+		</description>
+		<sheet>
+			<description>If a creature has a Bardic Inspiration die from you and casts a spell that restores hit points or deals damage, the creature can roll that die and choose a target affected by the spell. Add the number rolled as a bonus to the hit points regained or the damage dealt. The Bardic Inspiration die is then lost.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Magical Inspiration" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_MAGICAL_INSPIRATION">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_BARD_MAGICAL_INSPIRATION" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Bard, second level, 2nd level</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_BARD_MAGICAL_INSPIRATION" requirements="[level:bard:2]"/>
+		</rules>
+	</element>
+
+	<!-- Bardic Versatility -->
+	<element name="Bardic Versatility" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_BARD_BARDIC_VERSATILITY">
+		<description>
+			<p><i>4th-level bard feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following, representing a change in focus as you use your skills and magic:</p>
+			<ul>
+				<li>Replace one of the skills you chose for the Expertise feature with one of your other skill proficiencies that isn't benefiting from Expertise.</li>
+				<li>Replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the bard spell list.</li>
+			</ul>
+		</description>
+		<sheet>
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following: &#13;
+			• Replace one of the skills you chose for the Expertise feature with one of your other skill proficiencies that isn't benefiting from Expertise. &#13;
+			• Replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the bard spell list.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Bardic Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_BARDIC_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_BARD_BARDIC_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Bard, fourth level, 4th level, ASI, Ability Score Improvement, Expertise, skill, Spellcasting, spell</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_BARD_BARDIC_VERSATILITY" requirements="[level:bard:4]"/>
+		</rules>
+	</element>
+
 	<!-- Cleric -->
 	<!-- Additional Cleric Spells -->
 	<element name="Additional Cleric Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_ADDITIONAL_CLERIC_SPELLS">
 		<description>
 			<p><i>1st-level cleric feature</i></p>
-			<p>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<p>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
 			<table>
 				<thead>
 					<tr><td>Spell Level</td><td>Spells</td></tr>
 				</thead>
-				<tr><td>3rd</td><td><em>Aura of vitality, Spirit Shroud*</em></td></tr>
+				<tr><td>3rd</td><td><em>Aura of vitality, Spirit shroud*</em></td></tr>
 				<tr><td>4th</td><td><em>Aura of life, Aura of purity</em></td></tr>
-				<tr><td>5th</td><td><em>Summon Celestial*</em></td></tr>
+				<tr><td>5th</td><td><em>Summon celestial*</em></td></tr>
 				<tr><td>6th</td><td><em>Sunbeam</em></td></tr>
 				<tr><td>8th</td><td><em>Sunburst</em></td></tr>
 				<tr><td>9th</td><td><em>Power word heal</em></td></tr>
 			</table>
 		</description>
 		<sheet display="false">
-			<description>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+			<description>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
 		<rules>
 			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Cleric" level="5" />
@@ -62,17 +255,22 @@
 	</element>
 
 	<!-- Harness Divine Power -->
-	<element name="Harness Divine Power" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_HARNESS_DIVINE_POWER">
+	<element name="Harness Divine Power (Cleric)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_HARNESS_DIVINE_POWER">
 		<description>
 			<p><i>2nd-level cleric feature</i></p>
 			<p>You can expend a use of your Channel Divinity to fuel your spells. As a bonus action, you touch your holy symbol, utter a prayer, and regain one expended spell slot, the level of which can be no higher than half your proficiency bonus (rounded up). The number of times you can use this feature is based on the level you've reached in this class: 2nd level, once; 6th level, twice; and 18th level, thrice. You regain all expended uses when you finish a long rest.</p>
 		</description>
-		<sheet action="Bonus Action" usage="Channel Divinity">
+		<sheet action="Bonus Action" usage="{{harness divine power:usage}}/Long Rest" alt="Harness Divine Power">
 			<description>You touch your holy symbol, utter a prayer, and regain one expended spell slot, the level of which can be no higher than {{proficiency:half:up}}.</description>
 		</sheet>
+		<rules>
+			<stat name="harness divine power:usage" value="1" bonus="base"/>
+			<stat name="harness divine power:usage" value="2" bonus="base" requirements="[level:cleric:6]"/>
+			<stat name="harness divine power:usage" value="3" bonus="base" requirements="[level:cleric:18]"/>
+		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Harness Divine Power" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_HARNESS_DIVINE_POWER">
+	<element name="Optional Class Feature: Harness Divine Power (Cleric)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_HARNESS_DIVINE_POWER">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -154,6 +352,479 @@
 
 	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
 		<compendium display="false" />
+	</element>
+
+	<!-- Druid -->
+	<!-- Additional Druid Spells -->
+	<element name="Additional Druid Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_ADDITIONAL_DRUID_SPELLS">
+		<description>
+			<p><i>1st-level druid feature</i></p>
+			<p>The spells in the following list expand the druid spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>Protection from evil and good</em></td></tr>
+				<tr><td>2nd</td><td><em>Augury (ritual), Continual flame, Enlarge/Reduce, Summon beast*</em></td></tr>
+				<tr><td>3rd</td><td><em>Aura of vitality, Elemental weapon, Revivify, Summon fey*</em></td></tr>
+				<tr><td>4th</td><td><em>Divination (ritual), Fire shield, Summon elemental*</em></td></tr>
+				<tr><td>5th</td><td><em>Cone of cold</em></td></tr>
+				<tr><td>6th</td><td><em>Flesh to stone</em></td></tr>
+				<tr><td>7th</td><td><em>Symbol</em></td></tr>
+				<tr><td>8th</td><td><em>Incendiary cloud</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the druid spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" spellcasting="Druid"/>
+            <grant type="Spell" id="ID_PHB_SPELL_AUGURY" spellcasting="Druid" level="3" />
+            <grant type="Spell" id="ID_PHB_SPELL_CONTINUAL_FLAME" spellcasting="Druid" level="3" />
+            <grant type="Spell" id="ID_PHB_SPELL_ENLARGE_REDUCE" spellcasting="Druid" level="3" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SUMMON_BEAST" spellcasting="Druid" level="3" />
+            <grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Druid" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" spellcasting="Druid" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" spellcasting="Druid" level="5" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SUMMON_FEY" spellcasting="Druid" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_DIVINATION" spellcasting="Druid" level="7" />
+            <grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" spellcasting="Druid" level="7" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SUMMON_ELEMENTAL" spellcasting="Druid" level="7" />
+            <grant type="Spell" id="ID_PHB_SPELL_CONE_OF_COLD" spellcasting="Druid" level="9" />
+            <grant type="Spell" id="ID_PHB_SPELL_FLESH_TO_STONE" spellcasting="Druid" level="11" />
+            <grant type="Spell" id="ID_PHB_SPELL_SYMBOL" spellcasting="Druid" level="13" />
+            <grant type="Spell" id="ID_PHB_SPELL_INCENDIARY_CLOUD" spellcasting="Druid" level="15" />
+        </rules>
+	</element>
+
+	<element name="Optional Class Feature: Additional Druid Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_ADDITIONAL_DRUID_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_ADDITIONAL_DRUID_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Druid, first level, 1st level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_ADDITIONAL_DRUID_SPELLS" requirements="[level:druid:1]"/>
+		</rules>
+	</element>
+
+	<!-- Wild Companion -->
+	<element name="Wild Companion" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_WILD_COMPANION">
+		<description>
+			<p><i>2nd-level druid feature</i></p>
+			<p>You gain the ability to summon a spirit that assumes an animal form: as an action, you can expend a use of your Wild Shape feature to cast the find familiar spell, without material components.</p>
+			<p class="indent">When you cast the spell in this way, the familiar is a fey instead of a beast, and the familiar disappears after a number of hours equal to half your druid level.</p>
+		</description>
+		<sheet action="Action" usage="Wild Shape">
+			<description>You can expend a use of your Wild Shape feature to cast the find familiar spell, without material components. When you cast the spell in this way, the familiar is a fey instead of a beast, and the familiar disappears after {{level:druid:half}} hours.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Wild Companion" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_WILD_COMPANION">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_WILD_COMPANION" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Druid, second level, 2nd level, Wild Shape</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_WILD_COMPANION" requirements="[level:druid:2]"/>
+		</rules>
+	</element>
+
+	<!-- Cantrip Versatility -->
+	<element name="Cantrip Versatility (Druid)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_CANTRIP_VERSATILITY">
+		<description>
+			<p><i>4th-level druid feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the druid spell list.</p>
+		</description>
+		<sheet alt="Cantrip Versatility">
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the druid spell list.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Cantrip Versatility (Druid)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_CANTRIP_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_CANTRIP_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Druid, fourth level, 4th level</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_DRUID_CANTRIP_VERSATILITY" requirements="[level:druid:4]"/>
+		</rules>
+	</element>
+
+	<!-- Fighter -->
+	<!-- Martial Versatility -->
+	<element name="Martial Versatility (Fighter)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_FIGHTER_MARTIAL_VERSATILITY">
+		<description>
+			<p><i>4th-level fighter feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following, as you shift the focus of your martial practice:</p>
+			<ul>
+				<li>Replace a fighting style you know with another fighting style available to fighters.</li>
+				<li>If you know any maneuvers from the Battle Master archetype, you can replace one maneuver you know with a different maneuver.</li>
+			</ul>
+		</description>
+		<sheet>
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following: &#13;
+			• Replace a fighting style you know with another fighting style available to fighters. &#13;
+			• If you know any maneuvers from the Battle Master archetype, you can replace one maneuver you know with a different maneuver.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Martial Versatility (Fighter)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_FIGHTER_MARTIAL_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_FIGHTER_MARTIAL_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Fighter, fourth level, 4th level, ASI, Ability Score Improvement, fighting styles, maneuvers</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_FIGHTER_MARTIAL_VERSATILITY" requirements="[level:fighter:4]"/>
+		</rules>
+	</element>
+
+	<!-- Maneuver Options -->
+	<element name="Ambush" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_AMBUSH">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>When you make a Dexterity (Stealth) check or an initiative roll, you can expend one superiority die and add the die to the roll, provided you aren’t incapacitated.</p>
+		</description>
+		<sheet>
+			<description>When you make a Stealth check or an initiative roll, you can expend one superiority die and add the die to the roll, provided you aren’t incapacitated.</description>
+		</sheet>
+	</element>
+
+	<element name="Bait and Switch" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_BAIT_AND_SWITCH">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>When you’re within 5 feet of a creature on your turn, you can expend one superiority die and switch places with that creature, provided you spend at least 5 feet of movement and the creature is willing and isn’t incapacitated. This movement doesn’t provoke opportunity attacks.</p>
+			<p class="indent">Roll the superiority die. Until the start of your next turn, you or the other creature (your choice) gains a bonus to AC equal to the number rolled.</p>
+		</description>
+		<sheet>
+			<description>When you’re within 5 feet of a creature on your turn, you can expend one superiority die and switch places with that creature, provided you spend at least 5 feet of movement and the creature is willing and isn’t incapacitated. This movement doesn’t provoke opportunity attacks. Roll the superiority die. Until the start of your next turn, you or the other creature gains a bonus to AC equal to the number rolled.</description>
+		</sheet>
+	</element>
+
+	<element name="Brace" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_BRACE">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>When a creature you can see moves into the reach you have with the melee weapon you’re wielding, you can use your reaction to expend one superiority die and make one attack against the creature, using that weapon. If the attack hits, add the superiority die to the weapon’s damage roll.</p>
+		</description>
+		<sheet action="Reaction">
+			<description>When a creature you can see moves into the reach you have with the melee weapon you’re wielding, you can expend one superiority die and make one attack against the creature, using that weapon. If the attack hits, add the superiority die to the weapon’s damage roll.</description>
+		</sheet>
+	</element>
+
+	<element name="Commanding Presence" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_COMMANDING_PRESENCE">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>When you make a Charisma (Intimidation), a Charisma (Performance), or a Charisma (Persuasion) check, you can expend one superiority die and add the superiority die to the ability check.</p>
+		</description>
+		<sheet>
+			<description>When you make a Intimidation, a Performance, or a Persuasion check, you can expend one superiority die and add the superiority die to the ability check.</description>
+		</sheet>
+	</element>
+
+	<element name="Grappling Strike" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_GRAPPLING_STRIKE">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>Immediately after you hit a creature with a melee attack on your turn, you can expend one superiority die and then try to grapple the target as a bonus action (see the Player’s Handbook for rules on grappling). Add the superiority die to your Strength (Athletics) check.</p>
+		</description>
+		<sheet action="Bonus Action">
+			<description>Immediately after you hit a creature with a melee attack on your turn, you can expend one superiority die and then try to grapple the target. Add the superiority die to your Athletics check.</description>
+		</sheet>
+	</element>
+
+	<element name="Tactical Assessment" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_TACTICAL_ASSESSMENT">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>When you make an Intelligence (Investigation), an Intelligence (History), or a Wisdom (Insight) check, you can expend one superiority die and add the superiority die to the ability check.</p>
+		</description>
+		<sheet>
+			<description>When you make an Investigation, an History, or a Insight check, you can expend one superiority die and add the superiority die to the ability check.</description>
+		</sheet>
+	</element>
+
+	<element name="Quick Toss" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_QUICK_TOSS">
+		<supports>Maneuver, Battle Master</supports>
+		<description>
+			<p>As a bonus action, you can expend one superiority die and make a ranged attack with a weapon that has the thrown property. You can draw the weapon as part of making this attack. If you hit, add the superiority die to the weapon’s damage roll.</p>
+		</description>
+		<sheet action="Bonus Action">
+			<description>You can expend one superiority die and make a ranged attack with a weapon that has the thrown property. You can draw the weapon as part of making this attack. If you hit, add the superiority die to the weapon’s damage roll.</description>
+		</sheet>
+	</element>
+
+	<!-- Monk -->
+	<!-- Dedicated Weapon -->
+	<element name="Dedicated Weapon" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_DEDICATED_WEAPON">
+		<description>
+			<p><i>2nd-level monk feature</i></p>
+			<p>You train yourself to use a variety of weapons as monk weapons, not just simple melee weapons and shortswords. Whenever you finish a short or long rest, you can touch one weapon, focus your ki on it, and then count that weapon as a monk weapon until you use this feature again.</p>
+			<p class="indent">The chosen weapon must meet these criteria:</p>
+			<ul>
+				<li>The weapon must be a simple or martial weapon.</li>
+				<li>You must be proficient with it.</li>
+				<li>It must lack the heavy and special properties.</li>
+			</ul>
+		</description>
+		<sheet>
+			<description>Whenever you finish a short or long rest, you can touch one weapon, focus your ki on it, and then count that weapon as a monk weapon until you use this feature again. The chosen weapon must meet these criteria: &#13;
+			• The weapon must be a simple or martial weapon. &#13;
+			• You must be proficient with it.&#13;
+			• It must lack the heavy and special properties.</description> 
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Dedicated Weapon" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_DEDICATED_WEAPON">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_MONK_DEDICATED_WEAPON" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Monk, second level, 2nd level, Monk weapons</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_DEDICATED_WEAPON" requirements="[level:monk:2]"/>
+		</rules>
+	</element>
+
+	<!-- Ki-Fueled Attack -->
+	<element name="Ki-Fueled Attack" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_KI_FUELED_ATTACK">
+		<description>
+			<p><i>3rd-level monk feature</i></p>
+			<p>If you spend 1 ki point or more as part of your action on your turn, you can make one attack with an unarmed strike or a monk weapon as a bonus action before the end of the turn.</p>
+		</description>
+		<sheet action="Bonus Action">
+			<description>If you spend 1 ki point or more as part of your action on your turn, you can make one attack with an unarmed strike or a monk weapon before the end of the turn.</description> 
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Ki-Fueled Attack" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_KI_FUELED_ATTACK">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_MONK_KI_FUELED_ATTACK" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Monk, third level, 3rd level, bonus action</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_KI_FUELED_ATTACK" requirements="[level:monk:3]"/>
+		</rules>
+	</element>
+
+	<!-- Quickened Healing -->
+	<element name="Quickened Healing" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_QUICKENED_HEALING">
+		<description>
+			<p><i>4th-level monk feature</i></p>
+			<p>As an action, you can spend 2 ki points and roll a Martial Arts die. You regain a number of hit points equal to the number rolled plus your proficiency bonus.</p>
+		</description>
+		<sheet action="Action" usage="Ki">
+			<description>You can spend 2 ki points and roll a Martial Arts die. You regain a number of hit points equal to the number rolled plus {{proficiency}}.</description> 
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Quickened Healing" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_QUICKENED_HEALING">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_MONK_QUICKENED_HEALING" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Monk, fourth level, 4th level, ki, healing, martial arts die</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_QUICKENED_HEALING" requirements="[level:monk:4]"/>
+		</rules>
+	</element>
+
+	<!-- Focused Aim -->
+	<element name="Focused Aim" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_FOCUSED_AIM">
+		<description>
+			<p><i>5th-level monk feature</i></p>
+			<p>When you miss with an attack roll, you can spend 1 to 3 ki points to increase your attack roll by 2 for each of these ki points you spend, potentially turning the miss into a hit.</p>
+		</description>
+		<sheet usage="Ki">
+			<description>When you miss with an attack roll, you can spend 1 to 3 ki points to increase your attack roll by 2 for each of these ki points you spend, potentially turning the miss into a hit.</description> 
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Focused Aim" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_FOCUSED_AIM">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_MONK_FOCUSED_AIM" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Monk, fifth level, 5th level, ki, attack roll</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_MONK_FOCUSED_AIM" requirements="[level:monk:5]"/>
+		</rules>
+	</element>
+
+	<!-- Paladin -->
+	<!-- Additional Paladin Spells -->
+	<element name="Additional Paladin Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_ADDITIONAL_PALADIN_SPELLS">
+		<description>
+			<p><i>2nd-level paladin feature</i></p>
+			<p>The spells in the following list expand the paladin spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>2nd</td><td><em>Gentle repose, Prayer of healing, Warding bond</em></td></tr>
+				<tr><td>3rd</td><td><em>Spirit shroud*</em></td></tr>
+				<tr><td>5th</td><td><em>Summon celestial*</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the paladin spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_GENTLE_REPOSE" spellcasting="Paladin" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_PRAYER_OF_HEALING" spellcasting="Paladin" level="5" />
+            <grant type="Spell" id="ID_PHB_SPELL_WARDING_BOND" spellcasting="Paladin" level="5" />
+            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Paladin" level="9" />
+            <grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Paladin" level="17" />
+        </rules>
+	</element>
+
+	<element name="Optional Class Feature: Additional Paladin Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_ADDITIONAL_PALADIN_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_ADDITIONAL_PALADIN_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Paladin, second level, 2nd level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_ADDITIONAL_PALADIN_SPELLS" requirements="[level:paladin:2]"/>
+		</rules>
+	</element>
+
+	<!-- Harness Divine Power -->
+	<element name="Harness Divine Power (Paladin)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_HARNESS_DIVINE_POWER">
+		<description>
+			<p><i>3rd-level paladin feature</i></p>
+			<p>You can expend a use of your Channel Divinity to fuel your spells. As a bonus action, you touch your holy symbol, utter a prayer, and regain one expended spell slot, the level of which can be no higher than half your proficiency bonus (rounded up). The number of times you can use this feature is based on the level you've reached in this class: 3rd level, once; 7th level, twice; and 15th level, thrice. You regain all expended uses when you finish a long rest.</p>
+		</description>
+		<sheet action="Bonus Action" usage="{{harness divine power:usage}}/Long Rest" alt="Harness Divine Power">
+			<description>You touch your holy symbol, utter a prayer, and regain one expended spell slot, the level of which can be no higher than {{proficiency:half:up}}.</description>
+		</sheet>
+		<rules>
+			<stat name="harness divine power:usage" value="1" bonus="base"/>
+			<stat name="harness divine power:usage" value="2" bonus="base" requirements="[level:paladin:7]"/>
+			<stat name="harness divine power:usage" value="3" bonus="base" requirements="[level:paladin:15]"/>
+		</rules>
+	</element>
+
+	<element name="Optional Class Feature: Harness Divine Power (Paladin)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_HARNESS_DIVINE_POWER">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_HARNESS_DIVINE_POWER" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Paladin, third level, 3rd level, Channel Divinity</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_HARNESS_DIVINE_POWER" requirements="[level:paladin:3]"/>
+		</rules>
+	</element>
+
+	<!-- Martial Versatility -->
+	<element name="Martial Versatility (Paladin)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_MARTIAL_VERSATILITY">
+		<description>
+			<p><i>4th-level ranger feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to paladins. This replacement represents a shift of focus in your martial practice.</p>
+		</description>
+		<sheet alt="Martial Versatility">
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to paladins.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Martial Versatility (Paladin)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_MARTIAL_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_MARTIAL_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Paladin, fourth level, 4th level, fighting styles</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_MARTIAL_VERSATILITY" requirements="[level:paladin:4]"/>
+		</rules>
 	</element>
 
 	<!-- Ranger -->
@@ -291,7 +962,7 @@
 	<element name="Additional Ranger Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_ADDITIONAL_RANGER_SPELLS">
 		<description>
 			<p><i>2nd-level ranger feature</i></p>
-			<p>The spells in the following list expand the ranger spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<p>The spells in the following list expand the ranger spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
 			<table>
 				<thead>
 					<tr><td>Spell Level</td><td>Spells</td></tr>
@@ -304,7 +975,7 @@
 			</table>
 		</description>
 		<sheet display="false">
-			<description>The spells in the following list expand the ranger spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+			<description>The spells in the following list expand the ranger spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
 		</sheet>
 		<spellcasting name="Ranger" extend="true">
 			<extend>ID_PHB_SPELL_ENTANGLE</extend>
@@ -571,7 +1242,7 @@
 			<stat name="companion:speed:climb" value="40" bonus="base" />
 			<stat name="companion:proficiency" value="proficiency" bonus="base" />
 			<stat name="companion:proficiency" value="-2" bonus="base companion PB removal"/>
-            <grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_PRIMAL_BOND" />
+			<grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_PRIMAL_BOND" />
 		</rules>
 	</element>
 
@@ -660,7 +1331,7 @@
 			<stat name="companion:speed:swim" value="60" bonus="base" />
 			<stat name="companion:proficiency" value="proficiency" bonus="base" />
 			<stat name="companion:proficiency" value="-2" bonus="base companion PB removal"/>
-            <grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_PRIMAL_BOND" />
+			<grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_PRIMAL_BOND" />
 		</rules>
 	</element>
 
@@ -748,7 +1419,7 @@
 			<stat name="companion:speed:fly" value="60" bonus="base" />
 			<stat name="companion:proficiency" value="proficiency" bonus="base" />
 			<stat name="companion:proficiency" value="-2" bonus="base companion PB removal"/>
-            <grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_PRIMAL_BOND" />
+			<grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_PRIMAL_BOND" />
 		</rules>
 	</element>
 
@@ -801,6 +1472,399 @@
 		<sheet>
 			<description>Melee Weapon Attack: your spell attack modifier to hit, reach 5 ft., one target. Hit: 1d4+3+PB slashing damage</description>
 		</sheet>
+	</element>
+
+	<!-- Rogue -->
+	<!-- Steady Aim -->
+	<element name="Steady Aim" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_ROGUE_STEADY_AIM">
+		<description>
+			<p><i>3rd-level rogue feature</i></p>
+			<p>As a bonus action, you give yourself advantage on your next attack roll on the current turn. You can use this bonus action only if you haven't moved during this turn, and after you use the bonus action, your speed is 0 until the end of the current turn.</p>
+		</description>
+		<sheet action="Bonus Action">
+			<description>You give yourself advantage on your next attack roll on the current turn. You can use this bonus action only if you haven't moved during this turn, and after you use the bonus action, your speed is 0 until the end of the current turn.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Steady Aim" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_ROGUE_STEADY_AIM">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_ROGUE_STEADY_AIM" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Rogue, third level, 3rd level, advantage</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_ROGUE_STEADY_AIM" requirements="[level:rogue:3]"/>
+		</rules>
+	</element>
+
+	<!-- Sorcerer -->
+	<!-- Additional Sorcerer Spells -->
+	<element name="Additional Sorcerer Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_ADDITIONAL_SORCERER_SPELLS">
+		<description>
+			<p><i>1st-level sorcerer feature</i></p>
+			<p>The spells in the following list expand the sorcerer spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Cantrip</td><td><em>Booming blade*, Green-flame blade*, Lightning lure*, Mind sliver*, Sword burst*</em></td></tr>
+				<tr><td>1st</td><td><em>Grease, Tasha's caustic brew*</em></td></tr>
+				<tr><td>2nd</td><td><em>Flame blade, Flaming sphere, Magic weapon, Tasha's mind whip*</em></td></tr>
+				<tr><td>3rd</td><td><em>Intellect fortress*, Vampiric touch</em></td></tr>
+				<tr><td>4th</td><td><em>Fire shield</em></td></tr>
+				<tr><td>5th</td><td><em>Bigby's hand</em></td></tr>
+				<tr><td>6th</td><td><em>Flesh to stone, Otiluke's freezing sphere, Tasha's otherworldly guise</em></td></tr>
+				<tr><td>7th</td><td><em>Dream of the blue veil*</em></td></tr>
+				<tr><td>8th</td><td><em>Demiplane</em></td></tr>
+				<tr><td>9th</td><td><em>Blade of disaster*</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the sorcerer spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+		<spellcasting name="Sorcerer" extend="true">
+			<extend>ID_WOTC_TCOE_SPELL_BOOMING_BLADE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_GREENFLAME_BLADE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_LIGHTNING_LURE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_MIND_SLIVER</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SWORD_BURST</extend>
+			<extend>ID_PHB_SPELL_GREASE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_CAUSTIC_BREW</extend>
+			<extend>ID_PHB_SPELL_FLAME_BLADE</extend>
+			<extend>ID_PHB_SPELL_FLAMING_SPHERE</extend>
+			<extend>ID_PHB_SPELL_MAGIC_WEAPON</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_MIND_WHIP</extend>
+			<extend>ID_WOTC_TCOE_SPELL_INTELLECT_FORTRESS</extend>
+            <extend>ID_PHB_SPELL_VAMPIRIC_TOUCH</extend>
+			<extend>ID_PHB_SPELL_FIRE_SHIELD</extend>
+			<extend>ID_PHB_SPELL_BIGBYS_HAND</extend>
+            <extend>ID_PHB_SPELL_FLESH_TO_STONE</extend>
+            <extend>ID_PHB_SPELL_OTILUKES_FREEZING_SPHERE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_OTHERWORLDLY_GUISE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_DREAM_OF_THE_BLUE_VEIL</extend>
+            <extend>ID_PHB_SPELL_DEMIPLANE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_BLADE_OF_DISASTER</extend>
+		</spellcasting>
+	</element>
+
+	<element name="Optional Class Feature: Additional Sorcerer Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_ADDITIONAL_SORCERER_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_ADDITIONAL_SORCERER_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Sorcerer, first level, 1st level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_ADDITIONAL_SORCERER_SPELLS" requirements="[level:sorcerer:1]"/>
+		</rules>
+	</element>
+
+	<!-- Metamagic Options -->
+	<element name="Seeking Spell" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_METAMAGIC_SEEKING_SPELL">
+		<supports>Metamagic</supports>
+		<description>
+			<p>If you make an attack roll for a spell and miss, you can spend 2 sorcery points to reroll the d20, and you must use the new roll.</p>
+			<p class="indent">You can use Seeking Spell even if you have already used a different Metamagic option during the casting of the spell.</p>
+		</description>
+		<sheet>
+			<description>If you make an attack roll for a spell and miss, you can spend 2 sorcery points to reroll the d20, and you must use the new roll.
+			You can use Seeking Spell even if you have already used a different Metamagic option during the casting of the spell.</description>
+		</sheet>
+	</element>
+
+	<element name="Transmuted Spell" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_METAMAGIC_TRANSMUTED_SPELL">
+		<supports>Metamagic</supports>
+		<description>
+			<p>When you cast a spell that deals a type of damage from the following list, you can spend 1 sorcery point to change that damage type to one of the other listed types: acid, cold, fire, lightning, poison, thunder.</p>
+		</description>
+		<sheet>
+			<description>When you cast a spell that deals a type of damage from the following list, you can spend 1 sorcery point to change that damage type to one of the other listed types: acid, cold, fire, lightning, poison, thunder.</description>
+		</sheet>
+	</element>
+
+	<!-- Sorcerous Versatility -->
+	<element name="Sorcerous Versatility" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_SORCEROUS_VERSATILITY">
+		<description>
+			<p><i>4th-level sorcerer feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following, representing the magic within you flowing in new ways:</p>
+			<ul>
+				<li>Replace one of the options you chose for the Metamagic feature with a different Metamagic option available to you.</li>
+				<li>Replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the sorcerer spell list.</li>
+			</ul>
+		</description>
+		<sheet>
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following: &#13;
+			• Replace one of the options you chose for the Metamagic feature with a different Metamagic option available to you. &#13;
+			• Replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the sorcerer spell list.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Sorcerous Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_SORCEROUS_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_SORCEROUS_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Sorcerer, fourth level, 4th level, ASI, Ability Score Improvement, Metamagic, Spellcasting, cantrip</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_SORCEROUS_VERSATILITY" requirements="[level:sorcerer:4]"/>
+		</rules>
+	</element>
+
+	<!-- Magical Guidance -->
+	<element name="Magical Guidance" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_MAGICAL_GUIDANCE">
+		<description>
+			<p><i>5th-level sorcerer feature</i></p>
+			<p>You can tap into your inner wellspring of magic to try to conjure success from failure. When you make an ability check that fails, you can spend 1 sorcery point to reroll the d20, and you must use the new roll, potentially turning the failure into a success.</p>
+		</description>
+		<sheet usage="1 Sorcery Point">
+			<description>When you make an ability check that fails, you can reroll the d20, and you must use the new roll, potentially turning the failure into a success.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Magical Guidance" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_MAGICAL_GUIDANCE">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_MAGICAL_GUIDANCE" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Sorcerer, fifth level, 5th level, ability check, sorcery points</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_MAGICAL_GUIDANCE" requirements="[level:sorcerer:5]"/>
+		</rules>
+	</element>
+
+	<!-- Warlock -->
+	<!-- Additional Warlock Spells -->
+	<element name="Additional Warlock Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_WARLOCK_ADDITIONAL_WARLOCK_SPELLS">
+		<description>
+			<p><i>1st-level warlock feature</i></p>
+			<p>The spells in the following list expand the warlock spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Cantrip</td><td><em>Booming blade*, Green-flame blade*, Lightning lure*, Mind sliver*, Sword burst*</em></td></tr>
+				<tr><td>3rd</td><td><em>Intellect fortress*, Spirit shroud*, Summon fey*, Summon shadowspawn*, Summon undead*</em></td></tr>
+				<tr><td>4th</td><td><em>Summon aberration*</em></td></tr>
+				<tr><td>5th</td><td><em>Mislead, Planar binding, Teleportation circle</em></td></tr>
+				<tr><td>6th</td><td><em>Summon fiend*, Tasha's otherworldly guise</em></td></tr>
+				<tr><td>7th</td><td><em>Dream of the blue veil*</em></td></tr>
+				<tr><td>9th</td><td><em>Blade of disaster*, Gate, Weird</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the warlock spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+		<spellcasting name="Warlock" extend="true">
+			<extend>ID_WOTC_TCOE_SPELL_BOOMING_BLADE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_GREENFLAME_BLADE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_LIGHTNING_LURE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_MIND_SLIVER</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SWORD_BURST</extend>
+			<extend>ID_WOTC_TCOE_SPELL_INTELLECT_FORTRESS</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FEY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_SHADOWSPAWN</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_UNDEAD</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_ABERRATION</extend>
+			<extend>ID_PHB_SPELL_MISLEAD</extend>
+			<extend>ID_PHB_SPELL_PLANAR_BINDING</extend>
+            <extend>ID_PHB_SPELL_TELEPORTATION_CIRCLE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FIEND</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_OTHERWORLDLY_GUISE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_DREAM_OF_THE_BLUE_VEIL</extend>
+			<extend>ID_WOTC_TCOE_SPELL_BLADE_OF_DISASTER</extend>
+			<extend>ID_PHB_SPELL_GATE</extend>
+			<extend>ID_PHB_SPELL_WEIRD</extend>
+		</spellcasting>
+	</element>
+
+	<element name="Optional Class Feature: Additional Warlock Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WARLOCK_ADDITIONAL_WARLOCK_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_WARLOCK_ADDITIONAL_WARLOCK_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Warlock, first level, 1st level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_WARLOCK_ADDITIONAL_WARLOCK_SPELLS" requirements="[level:warlock:1]"/>
+		</rules>
+	</element>
+
+	<!-- Eldritch Versatility -->
+	<element name="Eldritch Versatility" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_WARLOCK_ELDRITCH_VERSATILITY">
+		<description>
+			<p><i>4th-level warlock feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following, representing a change of focus in your occult studies:</p>
+			<ul>
+				<li>Replace one cantrip you learned from this class's Pact Magic feature with another cantrip from the warlock spell list.</li>
+				<li>Replace the option you chose for the Pact Boon feature with one of that feature's other options.</li>
+				<li>If you're 12th level or higher, replace one spell from your Mystic Arcanum feature with another warlock spell of the same level.</li>
+			</ul>
+			<p>If this change makes you ineligible for any of your Eldritch Invocations, you must also replace them now, choosing invocations for which you qualify.</p>
+		</description>
+		<sheet>
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can do one of the following: &#13;
+			• Replace one cantrip you learned from this class's Pact Magic feature with another cantrip from the warlock spell list. &#13;
+			• Replace the option you chose for the Pact Boon feature with one of that feature's other options. &#13;
+			• If you're 12th level or higher, replace one spell from your Mystic Arcanum feature with another warlock spell of the same level. &#13;
+			If this change makes you ineligible for any of your Eldritch Invocations, you must also replace them now, choosing invocations for which you qualify.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Eldritch Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WARLOCK_ELDRITCH_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_WARLOCK_ELDRITCH_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Warlock, fourth level, 4th level, ASI, Ability Score Improvement, Metamagic, Spellcasting, cantrip</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_WARLOCK_ELDRITCH_VERSATILITY" requirements="[level:warlock:4]"/>
+		</rules>
+	</element>
+
+	<!-- Wizard -->
+	<!-- Additional Wizard Spells -->
+	<element name="Additional Wizard Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_WIZARD_ADDITIONAL_WIZARD_SPELLS">
+		<description>
+			<p><i>1st-level warlock feature</i></p>
+			<p>The spells in the following list expand the warlock spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. A spell's school of magic is noted, and if a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Cantrip</td><td><em>Booming blade* (evoc.), Green-flame blade* (evoc.), Lightning lure* (evoc.), Mind sliver* (ench.), Sword burst* (conj.)</em></td></tr>
+				<tr><td>1st</td><td><em>Tasha's caustic brew* (evoc.)</em></td></tr>
+				<tr><td>2nd</td><td><em>Augury (divin., ritual), Enhance ability (trans.), Tasha's mind whip* (ench.)</em></td></tr>
+				<tr><td>3rd</td><td><em>Intellect fortress* (abjur.), Speak with dead (necro.), Spirit shroud* (necro.), Summon fey* (conj.), Summon shadowspawn* (conj.), Summon undead* (conj.)</em></td></tr>
+				<tr><td>4th</td><td><em>Divination (divin., ritual), Summon aberration* (conj.), Summon construct* (conj.), Summon elemental* (conj.)</em></td></tr>
+				<tr><td>6th</td><td><em>Summon fiend* (conj.), Tasha's otherworldly guise (trans.)</em></td></tr>
+				<tr><td>7th</td><td><em>Dream of the blue veil* (conj.)</em></td></tr>
+				<tr><td>9th</td><td><em>Blade of disaster* (conj.)</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the warlock spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. A spell's school of magic is noted, and if a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3 of <i>Tasha’s Cauldron of Everything</i>). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+		<spellcasting name="Wizard" extend="true">
+			<extend>ID_WOTC_TCOE_SPELL_BOOMING_BLADE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_GREENFLAME_BLADE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_LIGHTNING_LURE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_MIND_SLIVER</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SWORD_BURST</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_CAUSTIC_BREW</extend>
+			<extend>ID_PHB_SPELL_AUGURY</extend>
+			<extend>ID_PHB_SPELL_ENHANCE_ABILITY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_MIND_WHIP</extend>
+			<extend>ID_WOTC_TCOE_SPELL_INTELLECT_FORTRESS</extend>
+			<extend>ID_PHB_SPELL_SPEAK_WITH_DEAD</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FEY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_SHADOWSPAWN</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_UNDEAD</extend>
+			<extend>ID_PHB_SPELL_DIVINATION</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_ABERRATION</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_CONSTRUCT</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FIEND</extend>
+			<extend>ID_WOTC_TCOE_SPELL_TASHAS_OTHERWORLDLY_GUISE</extend>
+			<extend>ID_WOTC_TCOE_SPELL_DREAM_OF_THE_BLUE_VEIL</extend>
+			<extend>ID_WOTC_TCOE_SPELL_BLADE_OF_DISASTER</extend>
+		</spellcasting>
+	</element>
+
+	<element name="Optional Class Feature: Additional Wizard Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WIZARD_ADDITIONAL_WIZARD_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_WIZARD_ADDITIONAL_WIZARD_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Wizard, first level, 1st level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_WIZARD_ADDITIONAL_WIZARD_SPELLS" requirements="[level:wizard:1]"/>
+		</rules>
+	</element>
+
+	<!-- Cantrip Formulas -->
+	<element name="Cantrip Formulas" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_WIZARD_CANTRIP_FORMULAS">
+		<description>
+			<p><i>3rd-level wizard feature</i></p>
+			<p>You have scribed a set of arcane formulas in your spellbook that you can use to formulate a cantrip in your mind. Whenever you finish a long rest and consult those formulas in your spellbook, you can replace one wizard cantrip you know with another cantrip from the wizard spell list.</p>
+		</description>
+		<sheet>
+			<description>Whenever you finish a long rest and consult those formulas in your spellbook, you can replace one wizard cantrip you know with another cantrip from the wizard spell list.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Cantrip Formulas" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WIZARD_CANTRIP_FORMULAS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_WIZARD_CANTRIP_FORMULAS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Wizard, third level, 3rd level, Spellcasting, cantrip</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_WIZARD_CANTRIP_FORMULAS" requirements="[level:wizard:3]"/>
+		</rules>
 	</element>
 
 	<!-- Fighting Styles -->
@@ -901,101 +1965,6 @@
 			<stat name="unarmed fighting:size" value="8" bonus="base" equipped="[primary:none],[secondary:none]" />
 			<stat name="unarmed fighting:ability modifier" value="strength:modifier" bonus="ability" />
 		</rules>
-	</element>
-
-	<!-- Metamagic -->
-	<element name="Seeking Spell" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_METAMAGIC_SEEKING_SPELL">
-		<supports>Metamagic</supports>
-		<description>
-			<p>If you make an attack roll for a spell and miss, you can spend 2 sorcery points to reroll the d20, and you must use the new roll.</p>
-			<p class="indent">You can use Seeking Spell even if you have already used a different Metamagic option during the casting of the spell.</p>
-		</description>
-		<sheet>
-			<description>If you make an attack roll for a spell and miss, you can spend 2 sorcery points to reroll the d20, and you must use the new roll.
-			You can use Seeking Spell even if you have already used a different Metamagic option during the casting of the spell.</description>
-		</sheet>
-	</element>
-
-	<element name="Transmuted Spell" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_SORCERER_METAMAGIC_TRANSMUTED_SPELL">
-		<supports>Metamagic</supports>
-		<description>
-			<p>When you cast a spell that deals a type of damage from the following list, you can spend 1 sorcery point to change that damage type to one of the other listed types: acid, cold, fire, lightning, poison, thunder.</p>
-		</description>
-		<sheet>
-			<description>When you cast a spell that deals a type of damage from the following list, you can spend 1 sorcery point to change that damage type to one of the other listed types: acid, cold, fire, lightning, poison, thunder.</description>
-		</sheet>
-	</element>
-
-	<!-- Maneuvers -->
-	<element name="Ambush" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_AMBUSH">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>When you make a Dexterity (Stealth) check or an initiative roll, you can expend one superiority die and add the die to the roll, provided you aren’t incapacitated.</p>
-		</description>
-		<sheet>
-			<description>When you make a Stealth check or an initiative roll, you can expend one superiority die and add the die to the roll, provided you aren’t incapacitated.</description>
-		</sheet>
-	</element>
-
-	<element name="Bait and Switch" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_BAIT_AND_SWITCH">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>When you’re within 5 feet of a creature on your turn, you can expend one superiority die and switch places with that creature, provided you spend at least 5 feet of movement and the creature is willing and isn’t incapacitated. This movement doesn’t provoke opportunity attacks.</p>
-			<p class="indent">Roll the superiority die. Until the start of your next turn, you or the other creature (your choice) gains a bonus to AC equal to the number rolled.</p>
-		</description>
-		<sheet>
-			<description>When you’re within 5 feet of a creature on your turn, you can expend one superiority die and switch places with that creature, provided you spend at least 5 feet of movement and the creature is willing and isn’t incapacitated. This movement doesn’t provoke opportunity attacks. Roll the superiority die. Until the start of your next turn, you or the other creature gains a bonus to AC equal to the number rolled.</description>
-		</sheet>
-	</element>
-
-	<element name="Brace" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_BRACE">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>When a creature you can see moves into the reach you have with the melee weapon you’re wielding, you can use your reaction to expend one superiority die and make one attack against the creature, using that weapon. If the attack hits, add the superiority die to the weapon’s damage roll.</p>
-		</description>
-		<sheet action="Reaction">
-			<description>When a creature you can see moves into the reach you have with the melee weapon you’re wielding, you can expend one superiority die and make one attack against the creature, using that weapon. If the attack hits, add the superiority die to the weapon’s damage roll.</description>
-		</sheet>
-	</element>
-
-	<element name="Commanding Presence" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_COMMANDING_PRESENCE">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>When you make a Charisma (Intimidation), a Charisma (Performance), or a Charisma (Persuasion) check, you can expend one superiority die and add the superiority die to the ability check.</p>
-		</description>
-		<sheet>
-			<description>When you make a Intimidation, a Performance, or a Persuasion check, you can expend one superiority die and add the superiority die to the ability check.</description>
-		</sheet>
-	</element>
-
-	<element name="Grappling Strike" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_GRAPPLING_STRIKE">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>Immediately after you hit a creature with a melee attack on your turn, you can expend one superiority die and then try to grapple the target as a bonus action (see the Player’s Handbook for rules on grappling). Add the superiority die to your Strength (Athletics) check.</p>
-		</description>
-		<sheet action="Bonus Action">
-			<description>Immediately after you hit a creature with a melee attack on your turn, you can expend one superiority die and then try to grapple the target. Add the superiority die to your Athletics check.</description>
-		</sheet>
-	</element>
-
-	<element name="Tactical Assessment" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_TACTICAL_ASSESSMENT">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>When you make an Intelligence (Investigation), an Intelligence (History), or a Wisdom (Insight) check, you can expend one superiority die and add the superiority die to the ability check.</p>
-		</description>
-		<sheet>
-			<description>When you make an Investigation, an History, or a Insight check, you can expend one superiority die and add the superiority die to the ability check.</description>
-		</sheet>
-	</element>
-
-	<element name="Quick Toss" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_MANEUVER_QUICK_TOSS">
-		<supports>Maneuver, Battle Master</supports>
-		<description>
-			<p>As a bonus action, you can expend one superiority die and make a ranged attack with a weapon that has the thrown property. You can draw the weapon as part of making this attack. If you hit, add the superiority die to the weapon’s damage roll.</p>
-		</description>
-		<sheet action="Bonus Action">
-			<description>You can expend one superiority die and make a ranged attack with a weapon that has the thrown property. You can draw the weapon as part of making this attack. If you hit, add the superiority die to the weapon’s damage roll.</description>
-		</sheet>
 	</element>
 
 </elements>

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -4,10 +4,804 @@
 		<name>Optional Class Features</name>
 		<description>The Optional Class Features from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="optional-class-features.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/optional-class-features.xml" />
 		</update>
 	</info>
+
+	<!-- Cleric -->
+	<!-- Additional Cleric Spells -->
+	<element name="Additional Cleric Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_ADDITIONAL_CLERIC_SPELLS">
+		<description>
+			<p><i>1st-level cleric feature</i></p>
+			<p>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>3rd</td><td><em>Aura of vitality, Spirit Shroud*</em></td></tr>
+				<tr><td>4th</td><td><em>Aura of life, Aura of purity</em></td></tr>
+				<tr><td>5th</td><td><em>Summon Celestial*</em></td></tr>
+				<tr><td>6th</td><td><em>Sunbeam</em></td></tr>
+				<tr><td>8th</td><td><em>Sunburst</em></td></tr>
+				<tr><td>9th</td><td><em>Power word heal</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the cleric spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_VITALITY" spellcasting="Cleric" level="5" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SPIRIT_SHROUD" spellcasting="Cleric" level="5" />
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_LIFE" spellcasting="Cleric" level="7" />
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_PURITY" spellcasting="Cleric" level="7" />
+			<grant type="Spell" id="ID_WOTC_TCOE_SPELL_SUMMON_CELESTIAL" spellcasting="Cleric" level="9" />
+			<grant type="Spell" id="ID_PHB_SPELL_SUNBEAM" spellcasting="Cleric" level="11" />
+			<grant type="Spell" id="ID_PHB_SPELL_SUNBURST" spellcasting="Cleric" level="15" />
+			<grant type="Spell" id="ID_PHB_SPELL_POWER_WORD_HEAL" spellcasting="Cleric" level="17" />
+		</rules>
+	</element>
+
+	<element name="Optional Class Feature: Additional Cleric Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_ADDITIONAL_CLERIC_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_ADDITIONAL_CLERIC_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Cleric, first level, 1st level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_ADDITIONAL_CLERIC_SPELLS" requirements="[level:cleric:1]"/>
+		</rules>
+	</element>
+
+	<!-- Harness Divine Power -->
+	<element name="Harness Divine Power" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_HARNESS_DIVINE_POWER">
+		<description>
+			<p><i>2nd-level cleric feature</i></p>
+			<p>You can expend a use of your Channel Divinity to fuel your spells. As a bonus action, you touch your holy symbol, utter a prayer, and regain one expended spell slot, the level of which can be no higher than half your proficiency bonus (rounded up). The number of times you can use this feature is based on the level you've reached in this class: 2nd level, once; 6th level, twice; and 18th level, thrice. You regain all expended uses when you finish a long rest.</p>
+		</description>
+		<sheet action="Bonus Action" usage="Channel Divinity">
+			<description>You touch your holy symbol, utter a prayer, and regain one expended spell slot, the level of which can be no higher than {{proficiency:half:up}}.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Harness Divine Power" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_HARNESS_DIVINE_POWER">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_HARNESS_DIVINE_POWER" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Cleric, second level, 2nd level, Channel Divinity</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_HARNESS_DIVINE_POWER" requirements="[level:cleric:2]"/>
+		</rules>
+	</element>
+
+	<!-- Cantrip Versatility -->
+	<element name="Cantrip Versatility (Cleric)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_CANTRIP_VERSATILITY">
+		<description>
+			<p><i>4th-level cleric feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the cleric spell list.</p>
+		</description>
+		<sheet alt="Cantrip Versatility">
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace one cantrip you learned from this class's Spellcasting feature with another cantrip from the cleric spell list.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Cantrip Versatility (Cleric)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_CANTRIP_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_CANTRIP_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Cleric, fourth level, 4th level</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_CANTRIP_VERSATILITY" requirements="[level:cleric:4]"/>
+		</rules>
+	</element>
+
+	<!-- Blessed Strikes -->
+	<element name="Blessed Strikes" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_BLESSED_STRIKES">
+		<description>
+			<p><i>8th-level cleric feature, which replaces the Divine Strike or Potent Spellcasting feature</i></p>
+			<p>You are blessed with divine might in battle. When a creature takes damage from one of your cantrips or weapon attacks, you can also deal 1d8 radiant damage to that creature. Once you deal this damage, you can't use this feature again until the start of your next turn.</p>
+		</description>
+		<sheet usage="1/Turn">
+			<description>When a creature takes damage from one of your cantrips or weapon attacks, you can also deal 1d8 radiant damage to that creature.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Blessed Strikes" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_BLESSED_STRIKES">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_BLESSED_STRIKES" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Cleric, eighth level, 8th level, Divine Strike, Potent Spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING" />
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_CLERIC_BLESSED_STRIKES" requirements="[level:cleric:8]"/>
+		</rules>
+	</element>
+
+	<element name="Divine Strike or Potent Spellcasting Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING">
+		<compendium display="false" />
+	</element>
+
+	<!-- Ranger -->
+	<!-- Deft Explorer -->
+	<element name="Deft Explorer" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER">
+		<description>
+			<p><i>1st-level ranger feature, which replaces the Natural Explorer feature</i></p>
+			<p>You are an unsurpassed explorer and survivor, both in the wilderness and in dealing with others on your travels. You gain the Canny benefit below, and you gain an additional benefit below when you reach 6th level and 10th level in this class.</p>
+			<h4>CANNY (1ST LEVEL)</h4>
+			<p>Choose one of your skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses the chosen skill.</p>
+			<p class="indent">You can also speak, read, and write two additional languages of your choice.</p>
+			<h4>ROVING (6TH LEVEL)</h4>
+			<p>Your walking speed increases by 5, and you gain a climbing speed and a swimming speed equal to your walking speed.</p>
+			<h4>TIRELESS (10TH LEVEL)</h4>
+			<p>As an action, you can give yourself a number of temporary hit points equal to 1d8 + your Wisdom modifier (minimum of 1 temporary hit point). You can use this action a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.</p>
+			<p class="indent">In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</p>
+		</description>
+		<sheet display="false">
+			<description>You are an unsurpassed explorer and survivor, both in the wilderness and in dealing with others on your travels. You gain the Canny benefit below, and you gain an additional benefit below when you reach 6th level and 10th level in this class.</description>
+		</sheet>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_CANNY"/>			
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_ROVING" requirements="[level:ranger:6]"/>			
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_TIRELESS" requirements="[level:ranger:10]"/>			
+		</rules>
+	</element>
+
+	<element name="Optional Class Feature: Deft Explorer" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_DEFT_EXPLORER">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, first level, 1st level, Canny, Roving, Tireless, Expertise, climbing, swimming, climb speed, swim speed, temporary hit points, Natural Explorer</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER" />
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER" requirements="[level:ranger:1]"/>
+		</rules>
+	</element>
+
+	<element name="Natural Explorer Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_NATURAL_EXPLORER">
+		<compendium display="false" />
+	</element>
+
+	<element name="Canny" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_CANNY">
+		<description>
+			<p>Choose one of your skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses the chosen skill.</p>
+			<p class="indent">You can also speak, read, and write two additional languages of your choice.</p>
+		</description>
+		<sheet display="false">
+			<description>Choose one of your skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses the chosen skill. You can also speak, read, and write two additional languages of your choice.</description>
+		</sheet>
+		<rules>
+			<select type="Class Feature" name="Expertise (Canny)" supports="Expertise"/>
+			<select type="Language" name="Language (Canny)" number="2" />			
+		</rules>
+	</element>
+
+	<element name="Roving" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_ROVING">
+		<description>
+			<p>Your walking speed increases by 5, and you gain a climbing speed and a swimming speed equal to your walking speed.</p>
+		</description>
+		<sheet display="false">
+			<description>Your walking speed increases by 5, and you gain a climbing speed and a swimming speed equal to your walking speed.</description>
+		</sheet>
+		<rules>
+			<stat name="speed" value="5" />
+			<stat name="speed:swim" value="speed" bonus="base" />
+			<stat name="speed:climb" value="speed" bonus="base" />
+		</rules>
+	</element>
+
+	<element name="Tireless" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_DEFT_EXPLORER_TIRELESS">
+		<description>
+			<p>As an action, you can give yourself a number of temporary hit points equal to 1d8 + your Wisdom modifier (minimum of 1 temporary hit point). You can use this action a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.</p>
+			<p class="indent">In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</p>
+		</description>
+		<sheet action="Action" usage="{{proficiency}}/Long Rest">
+			<description>You can give yourself a number of temporary hit points equal to 1d8 + {{tireless:hp}}. In addition, whenever you finish a short rest, your exhaustion level, if any, is decreased by 1.</description>
+		</sheet>
+		<rules>
+			<stat name="tireless:hp" value="1" bonus="base" />
+			<stat name="tireless:hp" value="wisdom:modifier" bonus="base" />
+		</rules>
+	</element>
+	
+	<!-- Favored Foe -->
+	<element name="Favored Foe" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_FAVORED_FOE">
+		<description>
+			<p><i>1st-level ranger feature, which replaces the Favored Enemy feature and works with the Foe Slayer feature</i></p>
+			<p>When you hit a creature with an attack roll, you can call on your mystical bond with nature to mark the target as your favored enemy for 1 minute or until you lose your concentration (as if you were concentrating on a spell).</p>
+			<p class="indent">The first time on each of your turns that you hit the favored enemy and deal damage to it, including when you mark it, you can increase that damage by 1d4.</p>
+			<p class="indent">You can use this feature to mark a favored enemy a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.</p>
+			<p class="indent">This feature's extra damage increases when you reach certain levels in this class: to 1d6 at 6th level and to 1d8 at 14th level.</p>
+		</description>
+		<sheet usage="{{proficiency}}/Long Rest">
+			<description>When you hit a creature with an attack roll, you can mark the target as your favored enemy for 1 minute or until you lose your concentration (as if you were concentrating on a spell). The first time on each of your turns that you hit the favored enemy and deal damage to it, including when you mark it, you can increase that damage by 1d4.</description>
+			<description level="6">When you hit a creature with an attack roll, you can mark the target as your favored enemy for 1 minute or until you lose your concentration (as if you were concentrating on a spell). The first time on each of your turns that you hit the favored enemy and deal damage to it, including when you mark it, you can increase that damage by 1d6.</description>
+			<description level="14">When you hit a creature with an attack roll, you can mark the target as your favored enemy for 1 minute or until you lose your concentration (as if you were concentrating on a spell). The first time on each of your turns that you hit the favored enemy and deal damage to it, including when you mark it, you can increase that damage by 1d8.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Favored Foe" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_FAVORED_FOE">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_FAVORED_FOE" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, first level, 1st level, mark, Favored Enemy</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY" />
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_FAVORED_FOE" requirements="[level:ranger:1]"/>
+		</rules>
+	</element>
+
+	<element name="Favored Enemy Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_FAVORED_ENEMY">
+		<compendium display="false" />
+	</element>
+
+	<!-- Additional Ranger Spells -->
+	<element name="Additional Ranger Spells" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_ADDITIONAL_RANGER_SPELLS">
+		<description>
+			<p><i>2nd-level ranger feature</i></p>
+			<p>The spells in the following list expand the ranger spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>Entangle, Searing smite</em></td></tr>
+				<tr><td>2nd</td><td><em>Aid, Enhance ability, Gust of wind, Magic weapon, Summon beast*</em></td></tr>
+				<tr><td>3rd</td><td><em>Elemental weapon, Meld into stone, Revivify, Summon fey*</em></td></tr>
+				<tr><td>4th</td><td><em>Dominate beast, Summon elemental*</em></td></tr>
+				<tr><td>5th</td><td><em>Greater restoration</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description>The spells in the following list expand the ranger spell list in the <i>Player's Handbook</i>. The list is organized by spell level, not character level. If a spell can be cast as a ritual, the ritual tag appears after the spell's name. Each spell is in the <i>Player's Handbook</i>, unless it has an asterisk (a spell in chapter 3). <i>Xanathar's Guide to Everything</i> also offers more spells.</description>
+		</sheet>
+		<spellcasting name="Ranger" extend="true">
+			<extend>ID_PHB_SPELL_ENTANGLE</extend>
+			<extend>ID_PHB_SPELL_SEARING_SMITE</extend>
+			<extend>ID_PHB_SPELL_AID</extend>
+			<extend>ID_PHB_SPELL_ENHANCE_ABILITY</extend>
+			<extend>ID_PHB_SPELL_GUST_OF_WIND</extend>
+			<extend>ID_PHB_SPELL_MAGIC_WEAPON</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_BEAST</extend>
+			<extend>ID_PHB_SPELL_ELEMENTAL_WEAPON</extend>
+			<extend>ID_PHB_SPELL_MELD_INTO_STONE</extend>
+			<extend>ID_PHB_SPELL_REVIVIFY</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_FEY</extend>
+			<extend>ID_PHB_SPELL_DOMINATE_BEAST</extend>
+			<extend>ID_WOTC_TCOE_SPELL_SUMMON_ELEMENTAL</extend>
+			<extend>ID_PHB_SPELL_GREATER_RESTORATION</extend>
+		</spellcasting>
+	</element>
+
+	<element name="Optional Class Feature: Additional Ranger Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_ADDITIONAL_RANGER_SPELLS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_ADDITIONAL_RANGER_SPELLS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, second level, 2nd level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_ADDITIONAL_RANGER_SPELLS" requirements="[level:ranger:2]"/>
+		</rules>
+	</element>
+
+	<!-- Spellcasting Focus -->
+	<element name="Spellcasting Focus (Ranger)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_SPELLCASTING_FOCUS">
+		<description>
+			<p><i>2nd-level ranger feature</i></p>
+			<p>You can use a druidic focus as a spellcasting focus for your ranger spells. A druidic focus might be a sprig of mistletoe or holly, a wand or rod made of yew or another special wood, a staff drawn whole from a living tree, or an object incorporating feathers, fur, bones, and teeth from sacred animals.</p>
+		</description>
+		<sheet alt="Spellcasting Focus">
+			<description>You can use a druidic focus as a spellcasting focus for your ranger spells.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Spellcasting Focus (Ranger)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_SPELLCASTING_FOCUS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_SPELLCASTING_FOCUS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, second level, 2nd level, spellcasting</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_SPELLCASTING_FOCUS" requirements="[level:ranger:2]"/>
+		</rules>
+	</element>
+
+	<!-- Primal Awareness -->
+	<element name="Primal Awareness" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_AWARENESS">
+		<description>
+			<p><i>3rd-level ranger feature, which replaces the Primeval Awareness feature</i></p>
+			<p>You can focus your awareness through the interconnections of nature: you learn additional spells when you reach certain levels in this class if you don't already know them, as shown in the Primal Awareness Spells table. These spells don't count against the number of ranger spells you know.</p>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>3rd</td><td><em>speak with animals</em></td></tr>
+				<tr><td>5th</td><td><em>beast sense</em></td></tr>
+				<tr><td>9th</td><td><em>speak with plants</em></td></tr>
+				<tr><td>13th</td><td><em>locate creature</em></td></tr>
+				<tr><td>17th</td><td><em>commune with nature</em></td></tr>
+			</table>
+			<p class="indent">You can cast each of these spells once without expending a spell slot. Once you cast a spell in this way, you can't do so again until you finish a long rest.</p>
+		</description>
+		<sheet display="false">
+			<description>You can focus your awareness through the interconnections of nature: you learn additional spells when you reach certain levels in this class if you don't already know them, as shown in the Primal Awareness Spells table. These spells don't count against the number of ranger spells you know.</description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_ANIMALS" spellcasting="Ranger" level="3" />
+			<grant type="Spell" id="ID_PHB_SPELL_BEAST_SENSE" spellcasting="Ranger" level="5" />
+			<grant type="Spell" id="ID_PHB_SPELL_SPEAK_WITH_PLANTS" spellcasting="Ranger" level="9" />
+			<grant type="Spell" id="ID_PHB_SPELL_LOCATE_CREATURE" spellcasting="Ranger" level="13" />
+			<grant type="Spell" id="ID_PHB_SPELL_COMMUNE_WITH_NATURE" spellcasting="Ranger" level="17" />
+		</rules>
+	</element>
+
+	<element name="Optional Class Feature: Primal Awareness" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_AWARENESS">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_AWARENESS" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, third level, 3rd level, spells, Primeval Awareness</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS" />
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_AWARENESS" requirements="[level:ranger:3]"/>
+		</rules>
+	</element>
+
+	<element name="Primeval Awareness Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_PRIMEVAL_AWARENESS">
+		<compendium display="false" />
+	</element>
+
+	<!-- Martial Versatility -->
+	<element name="Martial Versatility (Ranger)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_MARTIAL_VERSATILITY">
+		<description>
+			<p><i>4th-level ranger feature</i></p>
+			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to rangers. This replacement represents a shift of focus in your martial practice.</p>
+		</description>
+		<sheet alt="Martial Versatility">
+			<description>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to rangers.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Martial Versatility (Ranger)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_MARTIAL_VERSATILITY">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_MARTIAL_VERSATILITY" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, fourth level, 4th level, fighting styles</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_MARTIAL_VERSATILITY" requirements="[level:ranger:4]"/>
+		</rules>
+	</element>
+
+	<!-- Nature's Veil -->
+	<element name="Nature's Veil" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_NATURES_VEIL">
+		<description>
+			<p><i>10th-level ranger feature, which replaces the Hide in Plain Sight feature</i></p>
+			<p>You draw on the powers of nature to hide yourself from view briefly. As a bonus action, you can magically become invisible, along with any equipment you are wearing or carrying, until the start of your next turn.</p>
+			<p class="indent">You can use this feature a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.</p>
+		</description>
+		<sheet action="Bonus Action" usage="{{proficiency}}/Long Rest">
+			<description>You can magically become invisible, along with any equipment you are wearing or carrying, until the start of your next turn.</description>
+		</sheet>
+	</element>
+
+	<element name="Optional Class Feature: Nature's Veil" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_NATURES_VEIL">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_NATURES_VEIL" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, tenth level, 10th level, invisibility, Hide in Plain Sight</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT" />
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_NATURES_VEIL" requirements="[level:ranger:10]"/>
+		</rules>
+	</element>
+
+	<element name="Hide in Plain Sight Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_HIDE_IN_PLAIN_SIGHT">
+		<compendium display="false" />
+	</element>
+
+	<!-- Beast Master Companions: Primal Companion -->
+	<element name="Primal Companion" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION">
+		<description>
+			<p><i>3rd-level Beast Master feature, which replaces the Ranger's Companion feature</i></p>
+			<p>You magically summon a primal beast, which draws strength from your bond with nature. The beast is friendly to you and your companions and obeys your commands. Choose its stat block — Beast of the Land, Beast of the Sea, or Beast of the Sky — which uses your proficiency bonus (PB) in several places. You also determine the kind of animal the beast is, choosing a kind appropriate for the stat block. Whatever kind you choose, the beast bears primal markings, indicating its mystical origin.</p>
+			<p class="indent">In combat, the beast acts during your turn. It can move and use its reaction on its own, but the only action it takes is the Dodge action, unless you take a bonus action on your turn to command it to take another action. That action can be one in its stat block or some other action. You can also sacrifice one of your attacks when you take the Attack action to command the beast to take the Attack action. If you are incapacitated, the beast can take any action of its choice, not just Dodge.</p>
+			<p class="indent">If the beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st level or higher. The beast returns to life after 1 minute with all its hit points restored.</p>
+			<p class="indent">When you finish a long rest, you can summon a different primal beast. The new beast appears in an unoccupied space within 5 feet of you, and you choose its stat block and appearance. If you already have a beast from this feature, it vanishes when the new beast appears. The beast also vanishes if you die.</p>
+		</description>
+		<sheet>
+			<description>You magically summon a primal beast, which draws strength from your bond with nature. The beast is friendly to you and your companions and obeys your commands. Choose its stat block — Beast of the Land, Beast of the Sea, or Beast of the Sky — which uses your proficiency bonus (PB) in several places. You also determine the kind of animal the beast is, choosing a kind appropriate for the stat block. &#13;
+			In combat, the beast acts during your turn. It can move and use its reaction on its own, but the only action it takes is the Dodge action, unless you take a bonus action on your turn to command it to take another action. That action can be one in its stat block or some other action. You can also sacrifice one of your attacks when you take the Attack action to command the beast to take the Attack action. If you are incapacitated, the beast can take any action of its choice, not just Dodge. &#13;
+			If the beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st level or higher. The beast returns to life after 1 minute with all its hit points restored. &#13;
+			When you finish a long rest, you can summon a different primal beast. The new beast appears in an unoccupied space within 5 feet of you, and you choose its stat block and appearance. If you already have a beast from this feature, it vanishes when the new beast appears. The beast also vanishes if you die.</description>
+		</sheet>
+		<rules>
+			<select type="Companion" name="Primal Companion" supports="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND|ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA|ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY" />
+		</rules>
+	</element>
+
+	<element name="Optional Class Feature: Primal Companion" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_COMPANION">
+		<compendium display="false" />
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<div class="reference">
+				<div element="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION" />
+			</div>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="keywords">OCF, Ranger, third level, 3rd level, Beast Master</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION" />
+			<grant type="Class Feature" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION" requirements="ID_WOTC_ARCHETYPE_RANGER_BEAST_MASTER"/>
+		</rules>
+	</element>
+
+	<element name="Ranger's Companion Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_FEATURE_REPLACEMENT_RANGER_BEAST_MASTER_RANGER_COMPANION">
+		<compendium display="false" />
+	</element>
+
+	<!-- Beast Master Companions -->
+	<element name="Beast of the Land" type="Companion" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND">
+		<requirements>ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_COMPANION</requirements>
+		<setters>
+			<set name="size">Medium</set>
+			<set name="type">Beast</set>
+			<set name="alignment">unaligned</set>
+			<set name="ac">13 + PB (natural armor)</set>
+			<set name="hp">5 + five times your ranger level (the beast has a number of Hit Dice [d8s] equal to your ranger level)</set>
+			<set name="speed">40 ft., climb 40 ft.</set>
+			<set name="strength">14</set>
+			<set name="dexterity">14</set>
+			<set name="constitution">15</set>
+			<set name="intelligence">8</set>
+			<set name="wisdom">14</set>
+			<set name="charisma">11</set>
+			<set name="senses">darkvision 60 ft., passive Perception 12</set>
+			<set name="languages">understands the languages you speak</set>
+			<set name="challenge">—</set>
+			<set name="traits">ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_CHARGE, ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_PRIMAL_BOND</set>
+			<set name="actions">ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_MAUL></set>
+		</setters>
+		<rules>
+			<stat name="companion:ac" value="13" />
+			<stat name="companion:ac" value="proficiency" />
+			<stat name="companion:hp:max" value="5" bonus="base" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:speed" value="40" bonus="base" />
+			<stat name="companion:speed:climb" value="40" bonus="base" />
+			<stat name="companion:proficiency" value="proficiency" bonus="base" />
+			<stat name="companion:proficiency" value="-2" bonus="base companion PB removal"/>
+            <grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_PRIMAL_BOND" />
+		</rules>
+	</element>
+
+	<element name="Charge" type="Companion Trait" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_CHARGE">
+		<description>
+			<p>If the beast moves at least 20 feet straight toward a target and then hits it with a maul attack on the same turn, the target takes an extra ld6 slashing damage. If the target is a creature, it must succeed on a Strength saving throw against your spell save DC or be knocked prone.</p>
+		</description>
+		<sheet>
+			<description>If the beast moves at least 20 feet straight toward a target and then hits it with a maul attack on the same turn, the target takes an extra ld6 slashing damage. If the target is a creature, it must succeed on a Strength saving throw against your spell save DC or be knocked prone.</description>
+		</sheet>
+	</element>
+	<element name="Primal Bond" type="Companion Trait" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_PRIMAL_BOND">
+		<description>
+			<p>You can add your proficiency bonus to any ability check or saving throw that the beast makes.</p>
+		</description>
+		<sheet display="false">
+			<description>You can add your proficiency bonus to any ability check or saving throw that the beast makes.</description>
+		</sheet>
+		<rules>
+			<stat name="companion:acrobatics:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:animal handling:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:arcana:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:athletics:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:deception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:history:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:insight:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:intimidation:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:investigation:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:medicine:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:nature:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:performance:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:persuasion:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:religion:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:sleight of hand:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:stealth:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:survival:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:strength:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:dexterity:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:constitution:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:intelligence:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:wisdom:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:charisma:save:proficiency" value="companion:proficiency" bonus="base" />
+		</rules>
+	</element>
+	<element name="Maul" type="Companion Action" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_LAND_MAUL>">
+		<description>
+			<p><i>Melee Weapon Attack:</i> your spell attack modifier to hit, reach 5 ft., one target. <i>Hit:</i> 1d8+2+PB slashing damage.</p>
+		</description>
+		<sheet>
+			<description>Melee Weapon Attack: your spell attack modifier to hit, reach 5 ft., one target. Hit: 1d8+2+PB slashing damage.</description>
+		</sheet>
+	</element>
+
+	<element name="Beast of the Sea" type="Companion" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA">
+		<requirements>ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_COMPANION</requirements>
+		<setters>
+			<set name="size">Medium</set>
+			<set name="type">Beast</set>
+			<set name="alignment">unaligned</set>
+			<set name="ac">13 + PB (natural armor)</set>
+			<set name="hp">5 + five times your ranger level (the beast has a number of Hit Dice [d8s] equal to your ranger level)</set>
+			<set name="speed">5 ft., swim 60 ft.</set>
+			<set name="strength">14</set>
+			<set name="dexterity">14</set>
+			<set name="constitution">15</set>
+			<set name="intelligence">8</set>
+			<set name="wisdom">14</set>
+			<set name="charisma">11</set>
+			<set name="senses">darkvision 60 ft., passive Perception 12</set>
+			<set name="languages">understands the languages you speak</set>
+			<set name="challenge">—</set>
+			<set name="traits">ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_AMPHIBIOUS, ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_PRIMAL_BOND</set>
+			<set name="actions">ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_BINDING_STRIKE></set>
+		</setters>
+		<rules>
+			<stat name="companion:ac" value="13" />
+			<stat name="companion:ac" value="proficiency" />
+			<stat name="companion:hp:max" value="5" bonus="base" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:speed" value="5" bonus="base" />
+			<stat name="companion:speed:swim" value="60" bonus="base" />
+			<stat name="companion:proficiency" value="proficiency" bonus="base" />
+			<stat name="companion:proficiency" value="-2" bonus="base companion PB removal"/>
+            <grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_PRIMAL_BOND" />
+		</rules>
+	</element>
+
+	<element name="Amphibious" type="Companion Trait" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_AMPHIBIOUS">
+		<description>
+			<p>The beast can breathe both air and water.</p>
+		</description>
+		<sheet>
+			<description>The beast can breathe both air and water.</description>
+		</sheet>
+	</element>
+	<element name="Primal Bond" type="Companion Trait" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_PRIMAL_BOND">
+		<description>
+			<p>You can add your proficiency bonus to any ability check or saving throw that the beast makes.</p>
+		</description>
+		<sheet display="false">
+			<description>You can add your proficiency bonus to any ability check or saving throw that the beast makes.</description>
+		</sheet>
+		<rules>
+			<stat name="companion:acrobatics:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:animal handling:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:arcana:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:athletics:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:deception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:history:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:insight:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:intimidation:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:investigation:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:medicine:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:nature:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:performance:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:persuasion:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:religion:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:sleight of hand:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:stealth:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:survival:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:strength:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:dexterity:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:constitution:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:intelligence:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:wisdom:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:charisma:save:proficiency" value="companion:proficiency" bonus="base" />
+		</rules>
+	</element>
+	<element name="Binding Strike" type="Companion Action" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SEA_BINDING_STRIKE>">
+		<description>
+			<p><i>Melee Weapon Attack:</i> your spell attack modifier to hit, reach 5 ft., one target. <i>Hit:</i> 1d6+2+PB piercing or bludgeoning damage (your choice), and the target is grappled (escape DC equals your spell save DC). Until this grapple ends, the beast can't use this attack on another target.</p>
+		</description>
+		<sheet>
+			<description>Melee Weapon Attack: your spell attack modifier to hit, reach 5 ft., one target. Hit: 1d6+2+PB piercing or bludgeoning damage (your choice), and the target is grappled (escape DC equals your spell save DC). Until this grapple ends, the beast can't use this attack on another target.</description>
+		</sheet>
+	</element>
+
+	<element name="Beast of the Sky" type="Companion" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY">
+		<requirements>ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_COMPANION</requirements>
+		<setters>
+			<set name="size">Small</set>
+			<set name="type">Beast</set>
+			<set name="alignment">unaligned</set>
+			<set name="ac">13 + PB (natural armor)</set>
+			<set name="hp">4 + four times your ranger level (the beast has a number of Hit Dice [d6s] equal to your ranger level)</set>
+			<set name="speed">10 ft., fly 60 ft.</set>
+			<set name="strength">6</set>
+			<set name="dexterity">16</set>
+			<set name="constitution">13</set>
+			<set name="intelligence">8</set>
+			<set name="wisdom">14</set>
+			<set name="charisma">11</set>
+			<set name="senses">darkvision 60 ft., passive Perception 12</set>
+			<set name="languages">understands the languages you speak</set>
+			<set name="challenge">—</set>
+			<set name="traits">ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_FLYBY, ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_PRIMAL_BOND</set>
+			<set name="actions">ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_SHRED></set>
+		</setters>
+		<rules>
+			<stat name="companion:ac" value="13" />
+			<stat name="companion:ac" value="proficiency" />
+			<stat name="companion:hp:max" value="4" bonus="base" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:hp:max" value="level:ranger" />
+			<stat name="companion:speed" value="10" bonus="base" />
+			<stat name="companion:speed:fly" value="60" bonus="base" />
+			<stat name="companion:proficiency" value="proficiency" bonus="base" />
+			<stat name="companion:proficiency" value="-2" bonus="base companion PB removal"/>
+            <grant type="Companion Trait" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_PRIMAL_BOND" />
+		</rules>
+	</element>
+
+	<element name="Flyby" type="Companion Trait" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_FLYBY">
+		<description>
+			<p>The beast doesn't provoke opportunity attacks when it flies out of an enemy's reach.</p>
+		</description>
+		<sheet>
+			<description>The beast doesn't provoke opportunity attacks when it flies out of an enemy's reach.</description>
+		</sheet>
+	</element>
+	<element name="Primal Bond" type="Companion Trait" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_PRIMAL_BOND">
+		<description>
+			<p>You can add your proficiency bonus to any ability check or saving throw that the beast makes.</p>
+		</description>
+		<sheet display="false">
+			<description>You can add your proficiency bonus to any ability check or saving throw that the beast makes.</description>
+		</sheet>
+		<rules>
+			<stat name="companion:acrobatics:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:animal handling:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:arcana:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:athletics:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:deception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:history:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:insight:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:intimidation:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:investigation:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:medicine:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:nature:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:performance:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:persuasion:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:religion:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:sleight of hand:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:stealth:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:survival:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:strength:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:dexterity:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:constitution:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:intelligence:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:wisdom:save:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:charisma:save:proficiency" value="companion:proficiency" bonus="base" />
+		</rules>
+	</element>
+	<element name="Shred" type="Companion Action" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_RANGER_PRIMAL_COMPANION_BEAST_OF_THE_SKY_SHRED>">
+		<description>
+			<p><i>Melee Weapon Attack:</i> your spell attack modifier to hit, reach 5 ft., one target. <i>Hit:</i> 1d4+3+PB slashing damage</p>
+		</description>
+		<sheet>
+			<description>Melee Weapon Attack: your spell attack modifier to hit, reach 5 ft., one target. Hit: 1d4+3+PB slashing damage</description>
+		</sheet>
+	</element>
 
 	<!-- Fighting Styles -->
 	<element name="Blessed Warrior" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_FIGHTING_STYLE_BLESSED_WARRIOR">
@@ -72,7 +866,7 @@
 			<stat name="superior technique:size" value="6" bonus="size" />
 			<stat name="superior technique:size" value="superiority dice:size" bonus="size" />
 			<stat name="superior technique:dc" value="8" bonus="base" />
-			<stat name="superior technique:dc" value="proficiency" bonus="proficiency" />
+			<stat name="superior technique:dc" value="proficiency" bonus="base" />
 			<stat name="superior technique:dc:ability" value="strength:modifier" bonus="ability"/>
 			<stat name="superior technique:dc:ability" value="dexterity:modifier" bonus="ability"/>
 			<stat name="superior technique:dc" value="superior technique:dc:ability" bonus="ability" />
@@ -204,5 +998,4 @@
 		</sheet>
 	</element>
 
-	<!-- placeholder for other OCF -->
 </elements>

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -25,7 +25,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Primal Knowledge" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARBARIAN_PRIMAL_KNOWLEDGE">
+	<element name="Barbarian, LV03: Primal Knowledge" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARBARIAN_PRIMAL_KNOWLEDGE">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -34,8 +34,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Barbarian, third level, 3rd level, Skill Proficiency</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">third level, 3rd level, Skill Proficiency</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -55,7 +55,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Instinctive Pounce" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARBARIAN_INSTINCTIVE_POUNCE">
+	<element name="Barbarian, LV07: Instinctive Pounce" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARBARIAN_INSTINCTIVE_POUNCE">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -64,8 +64,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Barbarian, seventh level, 7th level, rage, speed</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">seventh level, 7th level, rage, speed</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -117,7 +117,7 @@
 		</spellcasting>
 	</element>
 
-	<element name="Optional Class Feature: Additional Bard Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_ADDITIONAL_BARD_SPELLS">
+	<element name="Bard, LV01: Additional Bard Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_ADDITIONAL_BARD_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -126,8 +126,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Bard, first level, 1st level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -147,7 +147,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Magical Inspiration" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_MAGICAL_INSPIRATION">
+	<element name="Bard, LV02: Magical Inspiration" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_MAGICAL_INSPIRATION">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -156,8 +156,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Bard, second level, 2nd level</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -183,7 +183,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Bardic Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_BARDIC_VERSATILITY">
+	<element name="Bard, LV04: Bardic Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_BARD_BARDIC_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -192,8 +192,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Bard, fourth level, 4th level, ASI, Ability Score Improvement, Expertise, skill, Spellcasting, spell</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, ASI, Ability Score Improvement, Expertise, skill, Spellcasting, spell</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -235,7 +235,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Additional Cleric Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_ADDITIONAL_CLERIC_SPELLS">
+	<element name="Cleric, LV01: Additional Cleric Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_ADDITIONAL_CLERIC_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -244,8 +244,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Cleric, first level, 1st level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -270,7 +270,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Harness Divine Power (Cleric)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_HARNESS_DIVINE_POWER">
+	<element name="Cleric, LV02: Harness Divine Power (Cleric)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_HARNESS_DIVINE_POWER">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -279,8 +279,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Cleric, second level, 2nd level, Channel Divinity</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level, Channel Divinity</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -300,7 +300,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Cantrip Versatility (Cleric)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_CANTRIP_VERSATILITY">
+	<element name="Cleric, LV02: Cantrip Versatility (Cleric)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_CANTRIP_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -309,8 +309,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Cleric, fourth level, 4th level</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -330,7 +330,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Blessed Strikes" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_BLESSED_STRIKES">
+	<element name="Cleric, LV08: Blessed Strikes" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_CLERIC_BLESSED_STRIKES">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -339,8 +339,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Cleric, eighth level, 8th level, Divine Strike, Potent Spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">eighth level, 8th level, Divine Strike, Potent Spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -393,7 +393,7 @@
         </rules>
 	</element>
 
-	<element name="Optional Class Feature: Additional Druid Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_ADDITIONAL_DRUID_SPELLS">
+	<element name="Druid, LV01: Additional Druid Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_ADDITIONAL_DRUID_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -402,8 +402,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Druid, first level, 1st level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -424,7 +424,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Wild Companion" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_WILD_COMPANION">
+	<element name="Druid, LV02: Wild Companion" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_WILD_COMPANION">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -433,8 +433,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Druid, second level, 2nd level, Wild Shape</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level, Wild Shape</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -454,7 +454,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Cantrip Versatility (Druid)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_CANTRIP_VERSATILITY">
+	<element name="Druid, LV04: Cantrip Versatility (Druid)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_DRUID_CANTRIP_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -463,8 +463,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Druid, fourth level, 4th level</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -491,7 +491,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Martial Versatility (Fighter)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_FIGHTER_MARTIAL_VERSATILITY">
+	<element name="Fighter, LV04: Martial Versatility (Fighter)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_FIGHTER_MARTIAL_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -500,8 +500,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Fighter, fourth level, 4th level, ASI, Ability Score Improvement, fighting styles, maneuvers</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, ASI, Ability Score Improvement, fighting styles, maneuvers</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -603,7 +603,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Dedicated Weapon" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_DEDICATED_WEAPON">
+	<element name="Monk, LV02: Dedicated Weapon" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_DEDICATED_WEAPON">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -612,8 +612,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Monk, second level, 2nd level, Monk weapons</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level, Monk weapons</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -633,7 +633,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Ki-Fueled Attack" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_KI_FUELED_ATTACK">
+	<element name="Monk, LV03: Ki-Fueled Attack" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_KI_FUELED_ATTACK">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -642,8 +642,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Monk, third level, 3rd level, bonus action</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">third level, 3rd level, bonus action</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -663,7 +663,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Quickened Healing" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_QUICKENED_HEALING">
+	<element name="Monk, LV04: Quickened Healing" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_QUICKENED_HEALING">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -672,8 +672,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Monk, fourth level, 4th level, ki, healing, martial arts die</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, ki, healing, martial arts die</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -693,7 +693,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Focused Aim" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_FOCUSED_AIM">
+	<element name="Monk, LV05: Focused Aim" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_MONK_FOCUSED_AIM">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -702,8 +702,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Monk, fifth level, 5th level, ki, attack roll</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fifth level, 5th level, ki, attack roll</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -739,7 +739,7 @@
         </rules>
 	</element>
 
-	<element name="Optional Class Feature: Additional Paladin Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_ADDITIONAL_PALADIN_SPELLS">
+	<element name="Paladin, LV02: Additional Paladin Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_ADDITIONAL_PALADIN_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -748,8 +748,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Paladin, second level, 2nd level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -774,7 +774,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Harness Divine Power (Paladin)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_HARNESS_DIVINE_POWER">
+	<element name="Paladin, LV03: Harness Divine Power (Paladin)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_HARNESS_DIVINE_POWER">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -783,8 +783,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Paladin, third level, 3rd level, Channel Divinity</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">third level, 3rd level, Channel Divinity</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -804,7 +804,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Martial Versatility (Paladin)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_MARTIAL_VERSATILITY">
+	<element name="Paladin, LV04: Martial Versatility (Paladin)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_PALADIN_MARTIAL_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -813,8 +813,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Paladin, fourth level, 4th level, fighting styles</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, fighting styles</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -848,7 +848,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Deft Explorer" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_DEFT_EXPLORER">
+	<element name="Ranger, LV01: Deft Explorer" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_DEFT_EXPLORER">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -857,8 +857,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, first level, 1st level, Canny, Roving, Tireless, Expertise, climbing, swimming, climb speed, swim speed, temporary hit points, Natural Explorer</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, Canny, Roving, Tireless, Expertise, climbing, swimming, climb speed, swim speed, temporary hit points, Natural Explorer</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -926,7 +926,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Favored Foe" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_FAVORED_FOE">
+	<element name="Ranger, LV01: Favored Foe" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_FAVORED_FOE">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -935,8 +935,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, first level, 1st level, mark, Favored Enemy</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, mark, Favored Enemy</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -983,7 +983,7 @@
 		</spellcasting>
 	</element>
 
-	<element name="Optional Class Feature: Additional Ranger Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_ADDITIONAL_RANGER_SPELLS">
+	<element name="Ranger, LV02: Additional Ranger Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_ADDITIONAL_RANGER_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -992,8 +992,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, second level, 2nd level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1013,7 +1013,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Spellcasting Focus (Ranger)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_SPELLCASTING_FOCUS">
+	<element name="Ranger, LV02: Spellcasting Focus (Ranger)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_SPELLCASTING_FOCUS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1022,8 +1022,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, second level, 2nd level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">second level, 2nd level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1061,7 +1061,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Primal Awareness" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_AWARENESS">
+	<element name="Ranger, LV03: Primal Awareness" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_AWARENESS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1070,8 +1070,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, third level, 3rd level, spells, Primeval Awareness</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">third level, 3rd level, spells, Primeval Awareness</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1092,7 +1092,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Martial Versatility (Ranger)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_MARTIAL_VERSATILITY">
+	<element name="Ranger, LV04: Martial Versatility (Ranger)" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_MARTIAL_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1101,8 +1101,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, fourth level, 4th level, fighting styles</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, fighting styles</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1123,7 +1123,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Nature's Veil" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_NATURES_VEIL">
+	<element name="Ranger, LV10: Nature's Veil" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_NATURES_VEIL">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1132,8 +1132,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, tenth level, 10th level, invisibility, Hide in Plain Sight</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">tenth level, 10th level, invisibility, Hide in Plain Sight</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1163,7 +1163,7 @@
 		</rules>
 	</element>
 
-	<element name="Optional Class Feature: Primal Companion" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_COMPANION">
+	<element name="Ranger, LV03: Primal Companion" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_RANGER_PRIMAL_COMPANION">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1172,8 +1172,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Ranger, third level, 3rd level, Beast Master</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">Ranger, third level, 3rd level, Beast Master</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1462,7 +1462,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Steady Aim" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_ROGUE_STEADY_AIM">
+	<element name="Rogue, LV03: Steady Aim" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_ROGUE_STEADY_AIM">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1471,8 +1471,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Rogue, third level, 3rd level, advantage</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">third level, 3rd level, advantage</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1531,7 +1531,7 @@
 		</spellcasting>
 	</element>
 
-	<element name="Optional Class Feature: Additional Sorcerer Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_ADDITIONAL_SORCERER_SPELLS">
+	<element name="Sorcerer, LV01: Additional Sorcerer Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_ADDITIONAL_SORCERER_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1540,8 +1540,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Sorcerer, first level, 1st level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1590,7 +1590,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Sorcerous Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_SORCEROUS_VERSATILITY">
+	<element name="Sorcerer, LV04: Sorcerous Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_SORCEROUS_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1599,8 +1599,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Sorcerer, fourth level, 4th level, ASI, Ability Score Improvement, Metamagic, Spellcasting, cantrip</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, ASI, Ability Score Improvement, Metamagic, Spellcasting, cantrip</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1620,7 +1620,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Magical Guidance" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_MAGICAL_GUIDANCE">
+	<element name="Sorcerer, LV05: Magical Guidance" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_SORCERER_MAGICAL_GUIDANCE">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1629,8 +1629,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Sorcerer, fifth level, 5th level, ability check, sorcery points</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fifth level, 5th level, ability check, sorcery points</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1685,7 +1685,7 @@
 		</spellcasting>
 	</element>
 
-	<element name="Optional Class Feature: Additional Warlock Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WARLOCK_ADDITIONAL_WARLOCK_SPELLS">
+	<element name="Warlock, LV01: Additional Warlock Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WARLOCK_ADDITIONAL_WARLOCK_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1694,8 +1694,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Warlock, first level, 1st level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1725,7 +1725,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Eldritch Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WARLOCK_ELDRITCH_VERSATILITY">
+	<element name="Warlock, LV04: Eldritch Versatility" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WARLOCK_ELDRITCH_VERSATILITY">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1734,8 +1734,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Warlock, fourth level, 4th level, ASI, Ability Score Improvement, Metamagic, Spellcasting, cantrip</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">fourth level, 4th level, ASI, Ability Score Improvement, Metamagic, Spellcasting, cantrip</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1794,7 +1794,7 @@
 		</spellcasting>
 	</element>
 
-	<element name="Optional Class Feature: Additional Wizard Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WIZARD_ADDITIONAL_WIZARD_SPELLS">
+	<element name="Wizard, LV01: Additional Wizard Spells" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WIZARD_ADDITIONAL_WIZARD_SPELLS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1803,8 +1803,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Wizard, first level, 1st level, spellcasting</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">first level, 1st level, spellcasting</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>
@@ -1824,7 +1824,7 @@
 		</sheet>
 	</element>
 
-	<element name="Optional Class Feature: Cantrip Formulas" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WIZARD_CANTRIP_FORMULAS">
+	<element name="Wizard, LV03: Cantrip Formulas" type="Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ITEM_OCF_WIZARD_CANTRIP_FORMULAS">
 		<compendium display="false" />
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
@@ -1833,8 +1833,8 @@
 			</div>
 		</description>
 		<setters>
-			<set name="category">Additional Feature</set>
-			<set name="keywords">OCF, Wizard, third level, 3rd level, Spellcasting, cantrip</set>
+			<set name="category">Optional Class Features</set>
+			<set name="keywords">third level, 3rd level, Spellcasting, cantrip</set>
 			<set name="slot">misc</set>
 			<set name="inventory-hidden">true</set>
 		</setters>

--- a/supplements/xanathars-guide-to-everything/archetypes/cleric-forgedomain.xml
+++ b/supplements/xanathars-guide-to-everything/archetypes/cleric-forgedomain.xml
@@ -1,143 +1,144 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-  <info>
-    <name>Forge Domain</name>
-    <description>The Forge Domain from Xanathar’s Guide to Everything</description>
-    <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
-    <update version="0.1.3">
-      <file name="cleric-forgedomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/xanathars-guide-to-everything/archetypes/cleric-forgedomain.xml" />
-    </update>
-  </info>
+	<info>
+		<name>Forge Domain</name>
+		<description>The Forge Domain from Xanathar’s Guide to Everything</description>
+		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
+		<update version="0.1.4">
+			<file name="cleric-forgedomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/xanathars-guide-to-everything/archetypes/cleric-forgedomain.xml" />
+		</update>
+	</info>
 
-  <element name="Forge Domain" type="Archetype" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_CLERIC_FORGE_DOMAIN">
-    <supports>Divine Domain</supports>
-    <description>
-      <p>The gods of the forge are patrons of artisans who work with metal, from a humble blacksmith who keeps a village in horseshoes and plow blades to the mighty elf artisan whose diamond-tipped arrows of mithral have felled demon lords. The gods of the forge teach that, with patience and hard work, even the most intractable metal can be transformed from a lump of ore to a beautifully wrought object. Clerics of these deities search for objects lost to the forces of darkness, liberate mines overrun by orcs, and uncover rare and wondrous materials necessary to create potent magic items. Followers of these gods take great pride in their work, and they are willing to craft and use heavy armor and powerful weapons to protect them. Deities of this domain include Gond, Reorx, Onatar, Moradin, Hephaestus, and Goibhniu</p>
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DOMAIN_SPELLS" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BONUS_PROFICIENCIES" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BLESSING_OF_THE_FORGE" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_CD_ARTISANS_BLESSING" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SOUL_OF_THE_FORGE" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DIVINE_STRIKE" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SAINT_OF_FORGE_AND_FIRE" />
-    </description>
-    <sheet>
-      <description>The gods of the forge are patrons of artisans who work with metal, from a humble blacksmith who keeps a village in horseshoes and plow blades to the mighty elf artisan whose diamond-tipped arrows of mithral have felled demon lords.</description>
-    </sheet>
-    <rules>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DOMAIN_SPELLS" level="1"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BLESSING_OF_THE_FORGE" level="1"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_CD_ARTISANS_BLESSING" level="2"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SOUL_OF_THE_FORGE" level="6"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DIVINE_STRIKE" level="8"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SAINT_OF_FORGE_AND_FIRE" level="17"/>
-    </rules>
-  </element>
-  
-  <element name="Domain Spells" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DOMAIN_SPELLS">
-    <description>
-      <p>You gain domain spells at the cleric levels listed in the Forge Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-      <h5>Forge Domain Spells</h5>
-      <table>
-        <thead>
-          <tr><td>Cleric Level</td><td>Spells</td></tr>
-        </thead>
-        <tr><td>1st</td><td><em>identify, searing smite</em></td></tr>
-        <tr><td>3rd</td><td><em>heat metal, magic weapon</em></td></tr>
-        <tr><td>5th</td><td><em>elemental weapon, protection from energy</em></td></tr>
-        <tr><td>7th</td><td><em>fabricate, wall of fire</em></td></tr> 
-        <tr><td>9th</td><td><em>animate objects, creation</em></td></tr>
-      </table>
-    </description>
-    <sheet display="false">
-      <description></description>
-    </sheet>
-    <rules>
-      <grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" level="1" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_SEARING_SMITE" level="1" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_HEAT_METAL" level="3" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_MAGIC_WEAPON" level="3" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" level="5" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" level="5" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_FABRICATE" level="7" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_WALL_OF_FIRE" level="7" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_ANIMATE_OBJECTS" level="9" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_CREATION" level="9" spellcasting="Cleric" prepared="true" />
-    </rules>
-  </element> 
-  <element name="Bonus Proficiencies" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BONUS_PROFICIENCIES">
-    <description>
-      <p>When you choose this domain at 1st level, you gain proficiency with heavy armor and smith’s tools.</p>
-    </description>
-    <sheet display="false">
-      <description>You gain proficiency with heavy armor and smith’s tools.</description>
-    </sheet>
-    <rules>
-      <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
-      <grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_SMITHS_TOOLS" />
-    </rules>
-  </element> 
-  <element name="Blessing of the Forge" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BLESSING_OF_THE_FORGE">
-    <description>
-      <p>At 1st level, you gain the ability to imbue magic into a weapon or armor. At the end of a long rest, you can touch one nonmagical object that is a suit of armor or a simple or martial weapon. Until the end of your next long rest or until you die, the object becomes a magic item, granting a +1 bonus to AC if it’s armor or a +1 bonus to attack and damage rolls if it’s a weapon.</p>
-      <p class="indent">Once you use this feature, you can’t use it again until you finish a long rest.</p>
-    </description>
-    <sheet>
-      <description>At the end of a long rest, you can touch one nonmagical object that is a suit of armor or a simple or martial weapon. Until the end of your next long rest or until you die, the object becomes a magic item, granting a +1 bonus to AC if it’s armor or a +1 bonus to attack and damage rolls if it’s a weapon.</description>
-    </sheet>
-  </element> 
-  <element name="Channel Divinity: Artisan’s Blessing" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_CD_ARTISANS_BLESSING">
-    <description>
-      <p>Starting at 2nd level, you can use your Channel Divinity to create simple items.</p>
-      <p class="indent">You conduct an hour-long ritual that crafts a nonmagical item that must include some metal: a simple or martial weapon, a suit of armor, ten pieces of ammunition, a set of tools, or another metal object (see chapter 5, “Equipment,” in the Player’s Handbook for examples of these items). The creation is completed at the end of the hour, coalescing in an unoccupied space of your choice on a surface within 5 feet of you.</p>
-      <p class="indent">The thing you create can be something that is worth no more than 100 gp. As part of this ritual, you must lay out metal, which can include coins, with a value equal to the creation. The metal irretrievably coalesces and transforms into the creation at the ritual’s end, magically forming even nonmetal parts of the creation.</p>
-      <p class="indent">The ritual can create a duplicate of a nonmagical item that contains metal, such as a key, if you possess the original during the ritual.</p>
-    </description>
-    <sheet alt="Artisan’s Blessing" usage="Channel Divinity">
-      <description>You conduct an hour-long ritual that crafts a nonmagical item that must include some metal.
-	  The thing you create can be something that is worth no more than 100 gp. As part of this ritual, you must lay out metal, which can include coins, with a value equal to the creation. The metal irretrievably coalesces and transforms into the creation at the ritual’s end, magically forming even nonmetal parts of the creation.
-	  The ritual can create a duplicate of a nonmagical item that contains metal, such as a key, if you possess the original during the ritual.</description>
-    </sheet>
-  </element> 
-  <element name="Soul of the Forge" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SOUL_OF_THE_FORGE">
-    <description>
-      <p>Starting at 6th level, your mastery of the forge grants you special abilities:</p>
-      <ul>
-        <li>You gain resistance to fire damage.</li>
-        <li>While wearing heavy armor, you gain a +1 bonus to AC.</li>
-      </ul>
-    </description>
-    <sheet>
-      <description>You gain resistance to fire damage. While wearing heavy armor, you gain a +1 bonus to AC.</description>
-    </sheet>
-    <rules>
-		<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_FIRE" />
-      <stat name="ac:misc" value="1" equipped="[armor:heavy]" />
-    </rules>
-  </element> 
-  <element name="Divine Strike" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DIVINE_STRIKE">
-    <description>
-      <p>At 8th level, you gain the ability to infuse your weapon strikes with the fiery power of the forge. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 fire damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
-    </description>
-    <sheet>
-      <description>Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 fire damage to the target.</description>
-      <description level="14">Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 fire damage to the target.</description>
-    </sheet>
-  </element> 
-  <element name="Saint of Forge and Fire" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SAINT_OF_FORGE_AND_FIRE">
-    <description>
-      <p>At 17th level, your blessed affinity with fire and metal becomes more powerful:</p>
-      <ul>
-        <li>You gain immunity to fire damage.</li>
-        <li>While wearing heavy armor, you have resistance to bludgeoning, piercing, and slashing damage from non-magical attacks.</li>
-      </ul>
-    </description>
-    <sheet>
-      <description>You gain immunity to fire damage. While wearing heavy armor, you have resistance to bludgeoning, piercing, and slashing damage from non-magical attacks.</description>
-    </sheet>
-    <rules>
-		<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_IMMUNITY_FIRE" />
-    </rules>
-  </element> 
+	<element name="Forge Domain" type="Archetype" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_CLERIC_FORGE_DOMAIN">
+		<supports>Divine Domain</supports>
+		<description>
+			<p>The gods of the forge are patrons of artisans who work with metal, from a humble blacksmith who keeps a village in horseshoes and plow blades to the mighty elf artisan whose diamond-tipped arrows of mithral have felled demon lords. The gods of the forge teach that, with patience and hard work, even the most intractable metal can be transformed from a lump of ore to a beautifully wrought object. Clerics of these deities search for objects lost to the forces of darkness, liberate mines overrun by orcs, and uncover rare and wondrous materials necessary to create potent magic items. Followers of these gods take great pride in their work, and they are willing to craft and use heavy armor and powerful weapons to protect them. Deities of this domain include Gond, Reorx, Onatar, Moradin, Hephaestus, and Goibhniu</p>
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BONUS_PROFICIENCIES" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BLESSING_OF_THE_FORGE" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_CD_ARTISANS_BLESSING" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SOUL_OF_THE_FORGE" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DIVINE_STRIKE" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SAINT_OF_FORGE_AND_FIRE" />
+		</description>
+		<sheet>
+			<description>The gods of the forge are patrons of artisans who work with metal, from a humble blacksmith who keeps a village in horseshoes and plow blades to the mighty elf artisan whose diamond-tipped arrows of mithral have felled demon lords.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BLESSING_OF_THE_FORGE" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_CD_ARTISANS_BLESSING" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SOUL_OF_THE_FORGE" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DIVINE_STRIKE" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SAINT_OF_FORGE_AND_FIRE" level="17"/>
+		</rules>
+	</element>
+	
+	<element name="Domain Spells" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DOMAIN_SPELLS">
+		<description>
+			<p>You gain domain spells at the cleric levels listed in the Forge Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+			<h5>Forge Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>identify, searing smite</em></td></tr>
+				<tr><td>3rd</td><td><em>heat metal, magic weapon</em></td></tr>
+				<tr><td>5th</td><td><em>elemental weapon, protection from energy</em></td></tr>
+				<tr><td>7th</td><td><em>fabricate, wall of fire</em></td></tr> 
+				<tr><td>9th</td><td><em>animate objects, creation</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_SEARING_SMITE" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_HEAT_METAL" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_MAGIC_WEAPON" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_ELEMENTAL_WEAPON" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_FABRICATE" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_WALL_OF_FIRE" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_ANIMATE_OBJECTS" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_CREATION" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element> 
+	<element name="Bonus Proficiencies" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BONUS_PROFICIENCIES">
+		<description>
+			<p>When you choose this domain at 1st level, you gain proficiency with heavy armor and smith’s tools.</p>
+		</description>
+		<sheet display="false">
+			<description>You gain proficiency with heavy armor and smith’s tools.</description>
+		</sheet>
+		<rules>
+			<grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
+			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_SMITHS_TOOLS" />
+		</rules>
+	</element> 
+	<element name="Blessing of the Forge" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_BLESSING_OF_THE_FORGE">
+		<description>
+			<p>At 1st level, you gain the ability to imbue magic into a weapon or armor. At the end of a long rest, you can touch one nonmagical object that is a suit of armor or a simple or martial weapon. Until the end of your next long rest or until you die, the object becomes a magic item, granting a +1 bonus to AC if it’s armor or a +1 bonus to attack and damage rolls if it’s a weapon.</p>
+			<p class="indent">Once you use this feature, you can’t use it again until you finish a long rest.</p>
+		</description>
+		<sheet>
+			<description>At the end of a long rest, you can touch one nonmagical object that is a suit of armor or a simple or martial weapon. Until the end of your next long rest or until you die, the object becomes a magic item, granting a +1 bonus to AC if it’s armor or a +1 bonus to attack and damage rolls if it’s a weapon.</description>
+		</sheet>
+	</element> 
+	<element name="Channel Divinity: Artisan’s Blessing" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_CD_ARTISANS_BLESSING">
+		<description>
+			<p>Starting at 2nd level, you can use your Channel Divinity to create simple items.</p>
+			<p class="indent">You conduct an hour-long ritual that crafts a nonmagical item that must include some metal: a simple or martial weapon, a suit of armor, ten pieces of ammunition, a set of tools, or another metal object (see chapter 5, “Equipment,” in the Player’s Handbook for examples of these items). The creation is completed at the end of the hour, coalescing in an unoccupied space of your choice on a surface within 5 feet of you.</p>
+			<p class="indent">The thing you create can be something that is worth no more than 100 gp. As part of this ritual, you must lay out metal, which can include coins, with a value equal to the creation. The metal irretrievably coalesces and transforms into the creation at the ritual’s end, magically forming even nonmetal parts of the creation.</p>
+			<p class="indent">The ritual can create a duplicate of a nonmagical item that contains metal, such as a key, if you possess the original during the ritual.</p>
+		</description>
+		<sheet alt="Artisan’s Blessing" usage="Channel Divinity">
+			<description>You conduct an hour-long ritual that crafts a nonmagical item that must include some metal.
+			The thing you create can be something that is worth no more than 100 gp. As part of this ritual, you must lay out metal, which can include coins, with a value equal to the creation. The metal irretrievably coalesces and transforms into the creation at the ritual’s end, magically forming even nonmetal parts of the creation.
+			The ritual can create a duplicate of a nonmagical item that contains metal, such as a key, if you possess the original during the ritual.</description>
+		</sheet>
+	</element> 
+	<element name="Soul of the Forge" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SOUL_OF_THE_FORGE">
+		<description>
+			<p>Starting at 6th level, your mastery of the forge grants you special abilities:</p>
+			<ul>
+				<li>You gain resistance to fire damage.</li>
+				<li>While wearing heavy armor, you gain a +1 bonus to AC.</li>
+			</ul>
+		</description>
+		<sheet>
+			<description>You gain resistance to fire damage. While wearing heavy armor, you gain a +1 bonus to AC.</description>
+		</sheet>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_FIRE" />
+			<stat name="ac:misc" value="1" equipped="[armor:heavy]" />
+		</rules>
+	</element> 
+	<element name="Divine Strike" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
+			<p>At 8th level, you gain the ability to infuse your weapon strikes with the fiery power of the forge. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 fire damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
+		</description>
+		<sheet>
+			<description>Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 fire damage to the target.</description>
+			<description level="14">Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 fire damage to the target.</description>
+		</sheet>
+	</element> 
+	<element name="Saint of Forge and Fire" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_FORGE_DOMAIN_SAINT_OF_FORGE_AND_FIRE">
+		<description>
+			<p>At 17th level, your blessed affinity with fire and metal becomes more powerful:</p>
+			<ul>
+				<li>You gain immunity to fire damage.</li>
+				<li>While wearing heavy armor, you have resistance to bludgeoning, piercing, and slashing damage from non-magical attacks.</li>
+			</ul>
+		</description>
+		<sheet>
+			<description>You gain immunity to fire damage. While wearing heavy armor, you have resistance to bludgeoning, piercing, and slashing damage from non-magical attacks.</description>
+		</sheet>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_IMMUNITY_FIRE" />
+		</rules>
+	</element> 
 </elements>

--- a/supplements/xanathars-guide-to-everything/archetypes/cleric-gravedomain.xml
+++ b/supplements/xanathars-guide-to-everything/archetypes/cleric-gravedomain.xml
@@ -1,121 +1,122 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-  <info>
-    <name>Grave Domain</name>
-    <description>The Grave Domain from Xanathar’s Guide to Everything</description>
-    <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
-    <update version="0.1.7">
-      <file name="cleric-gravedomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/xanathars-guide-to-everything/archetypes/cleric-gravedomain.xml" />
-    </update>
-  </info>
-  <element name="Grave Domain" type="Archetype" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_CLERIC_GRAVE_DOMAIN">
-    <supports>Divine Domain</supports>
-    <description>
-      <p>Gods of the grave watch over the line between life and death. To these deities, death and the afterlife are a foundational part of the multiverse. To desecrate the peace of the dead is an abomination. Deities of the grave include Kelemvor, Wee jas, the ancestral spirits of the Undying Court, Hades, Anubis, and Osiris. Followers of these deities seek to put wandering spirits to rest, destroy the undead, and ease the suffering of the dying. Their magic also allows them to stave off death for a time. particularly for a person who still has some great work to accomplish in the world. This is a delay of death, not a denial of it, for death will eventually get its due.</p>
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_DOMAIN_SPELLS" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CIRCLE_OF_MORTALITY" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_EYES_OF_THE_GRAVE" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CD_PATH_TO_THE_GRAVE" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_SENTINEL_AT_DEATHS_DOOR" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_POTENT_SPELLCASTING" />
-      <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_KEEPER_OF_SOULS" />
-    </description>
-    <sheet>
-      <description>Gods of the grave watch over the line between life and death. To these deities, death and the afterlife are a foundational part of the multiverse. To desecrate the peace of the dead is an abomination.</description>
-    </sheet>
-    <rules>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_DOMAIN_SPELLS" level="1"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CIRCLE_OF_MORTALITY" level="1"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_EYES_OF_THE_GRAVE" level="1"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CD_PATH_TO_THE_GRAVE" level="2"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_SENTINEL_AT_DEATHS_DOOR" level="6"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_POTENT_SPELLCASTING" level="8"/>
-      <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_KEEPER_OF_SOULS" level="17"/>
-    </rules>
-  </element>
-  <element name="Domain Spells" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_DOMAIN_SPELLS">
-    <description>
-      <p>You gain domain spells at the cleric levels listed in the Grave Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-      <h5>Grave Domain Spells</h5>
-      <table>
-        <thead>
-          <tr><td>Cleric Level</td><td>Spells</td></tr>
-        </thead>
-        <tr><td>1st</td><td><em>bane, false life</em></td></tr>
-        <tr><td>3rd</td><td><em>gentle repose, ray of enfeeblement</em></td></tr>
-        <tr><td>5th</td><td><em>revivify, vampiric touch</em></td></tr>
-        <tr><td>7th</td><td><em>blight, death ward</em></td></tr>
-        <tr><td>9th</td><td><em>antilife shell, raise dead</em></td></tr>
-      </table>
-    </description>
-    <sheet>
-      <description></description>
-    </sheet>
-    <rules>
-      <grant type="Spell" id="ID_PHB_SPELL_BANE" level="1" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_FALSE_LIFE" level="1" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_GENTLE_REPOSE" level="3" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_RAY_OF_ENFEEBLEMENT" level="3" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" level="5" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_VAMPIRIC_TOUCH" level="5" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_BLIGHT" level="7" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_DEATH_WARD" level="7" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_ANTILIFE_SHELL" level="9" spellcasting="Cleric" prepared="true" />
-      <grant type="Spell" id="ID_PHB_SPELL_RAISE_DEAD" level="9" spellcasting="Cleric" prepared="true" />
-    </rules>
-  </element>
-  <element name="Circle of Mortality" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CIRCLE_OF_MORTALITY">
-    <description>
-      <p>At 1st level, you gain the ability to manipulate the line between life and death. When you would normally roll one or more dice to restore hit points with a spell to a creature at 0 hit points, you instead use the highest number possible for each die.</p>
-      <p class="indent">In addition, you learn the<i>spare the dying cantrip</i>, which doesn’t count against the number of cleric cantrips you know. For you, it has a range of 30 feet, and you can cast it as a bonus action.</p>
-    </description>
-    <sheet>
-      <description>When rolling dice to restore HP with a spell, to a creature at 0HP, instead use the highest number possible for each die. Your <i>spare the dying</i> cantrip, has a range of 30ft and is a bonus action.</description>
-    </sheet>
-    <rules>
-      <grant type="Spell" id="ID_PHB_SPELL_SPARE_THE_DYING" spellcasting="Cleric" />
-    </rules>
-  </element>
-  <element name="Eyes of the Grave" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_EYES_OF_THE_GRAVE">
-    <description>
-      <p>At lst level, you gain the ability to occasionally sense the presence of the undead, whose existence is an insult to the natural cycle of life. As an action, you can open your awareness to magically detect undead. Until the end of your next turn, you know the location of any undead within 60 feet of you that isn’t behind total cover and that isn’t protected from divination magic. This sense doesn’t tell you anything about a creature's capabilities or identity.</p>
-      <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.</p>
-    </description>
-    <sheet>
-      <description>{{wisdom:modifier}} times per long rest, as an action you know the location of any undead within 60 feet of you that isn’t behind total cover and that isn’t protected from divination magic.</description>
-    </sheet>
-  </element>
-  <element name="Channel Divinity: Path to the Grave" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CD_PATH_TO_THE_GRAVE">
-    <description>
-      <p>Starting at 2nd level, you can use your Channel Divinity to mark another creature’s life force for termination.</p>
-      <p class="indent">As an action, you choose one creature you can see within 30 feet of you, cursing it until the end of your next turn. The next time you or an ally of yours hits the cursed creature with an attack, the creature has vulnerability to all of that attack's damage, and then the curse ends.</p>
-    </description>
-    <sheet alt="Path to the Grave" action="Action" usage="Channel Divinity">
-      <description>Choose one creature you can see within 30ft, and curse it until the end of your next turn. The next time you or an ally of yours hits the cursed creature with an attack, the creature has vulnerability to all of that attack's damage, and then the curse ends.</description>
-    </sheet>
-  </element>
-  <element name="Sentinel at Death's Door" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_SENTINEL_AT_DEATHS_DOOR">
-    <description>
-      <p>At 6th level, you gain the ability to impede death’s progress. As a reaction when you or a creature you can see within 30 feet of you suffers a critical hit, you can turn that hit into a normal hit. Any effects triggered by a critical hit are canceled. You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.</p>
-    </description>
-    <sheet action="Reaction">
-      <description>When you or a creature you can see within 30ft of you suffers a critical hit, turn that hit into a normal hit. ({{wisdom:modifier}}/day)</description>
-    </sheet>
-  </element>
-  <element name="Potent Spellcasting" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_POTENT_SPELLCASTING">
-    <description>
-      <p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
-    </description>
-    <sheet>
-      <description>Add {{wisdom:modifier}} to damage dealt with a cleric cantrip.</description>
-    </sheet>
-  </element>
-  <element name="Keeper of Souls" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_KEEPER_OF_SOULS">
-    <description>
-      <p>Starting at 17th level. you can seize a trace of vitality from a parting soul and use it to heal the living. When an enemy you can see dies within 60 feet of you, you or one creature of your choice that is within 60 feet of you regains hit points equal to the enemy’s number of Hit Dice. You can use this feature only if you aren’t incapacitated. Once you use it, you can't do so again until the start of your next turn.</p>
-    </description>
-    <sheet>
-      <description>Once per turn, when an enemy you can see dies within 60 feet of you, you or one creature of your choice that is within 60 feet of you regains hit points equal to the enemy’s number of Hit Dice.</description>
-    </sheet>
-  </element>
+	<info>
+		<name>Grave Domain</name>
+		<description>The Grave Domain from Xanathar’s Guide to Everything</description>
+		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
+		<update version="0.1.8">
+			<file name="cleric-gravedomain.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/xanathars-guide-to-everything/archetypes/cleric-gravedomain.xml" />
+		</update>
+	</info>
+	<element name="Grave Domain" type="Archetype" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_CLERIC_GRAVE_DOMAIN">
+		<supports>Divine Domain</supports>
+		<description>
+			<p>Gods of the grave watch over the line between life and death. To these deities, death and the afterlife are a foundational part of the multiverse. To desecrate the peace of the dead is an abomination. Deities of the grave include Kelemvor, Wee jas, the ancestral spirits of the Undying Court, Hades, Anubis, and Osiris. Followers of these deities seek to put wandering spirits to rest, destroy the undead, and ease the suffering of the dying. Their magic also allows them to stave off death for a time. particularly for a person who still has some great work to accomplish in the world. This is a delay of death, not a denial of it, for death will eventually get its due.</p>
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CIRCLE_OF_MORTALITY" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_EYES_OF_THE_GRAVE" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CD_PATH_TO_THE_GRAVE" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_SENTINEL_AT_DEATHS_DOOR" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_POTENT_SPELLCASTING" />
+			<div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_KEEPER_OF_SOULS" />
+		</description>
+		<sheet>
+			<description>Gods of the grave watch over the line between life and death. To these deities, death and the afterlife are a foundational part of the multiverse. To desecrate the peace of the dead is an abomination.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CIRCLE_OF_MORTALITY" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_EYES_OF_THE_GRAVE" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CD_PATH_TO_THE_GRAVE" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_SENTINEL_AT_DEATHS_DOOR" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_POTENT_SPELLCASTING" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_KEEPER_OF_SOULS" level="17"/>
+		</rules>
+	</element>
+	<element name="Domain Spells" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_DOMAIN_SPELLS">
+		<description>
+			<p>You gain domain spells at the cleric levels listed in the Grave Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+			<h5>Grave Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>bane, false life</em></td></tr>
+				<tr><td>3rd</td><td><em>gentle repose, ray of enfeeblement</em></td></tr>
+				<tr><td>5th</td><td><em>revivify, vampiric touch</em></td></tr>
+				<tr><td>7th</td><td><em>blight, death ward</em></td></tr>
+				<tr><td>9th</td><td><em>antilife shell, raise dead</em></td></tr>
+			</table>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_BANE" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_FALSE_LIFE" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_GENTLE_REPOSE" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_RAY_OF_ENFEEBLEMENT" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_REVIVIFY" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_VAMPIRIC_TOUCH" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_BLIGHT" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DEATH_WARD" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_ANTILIFE_SHELL" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_RAISE_DEAD" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element>
+	<element name="Circle of Mortality" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CIRCLE_OF_MORTALITY">
+		<description>
+			<p>At 1st level, you gain the ability to manipulate the line between life and death. When you would normally roll one or more dice to restore hit points with a spell to a creature at 0 hit points, you instead use the highest number possible for each die.</p>
+			<p class="indent">In addition, you learn the<i>spare the dying cantrip</i>, which doesn’t count against the number of cleric cantrips you know. For you, it has a range of 30 feet, and you can cast it as a bonus action.</p>
+		</description>
+		<sheet>
+			<description>When rolling dice to restore HP with a spell, to a creature at 0HP, instead use the highest number possible for each die. Your <i>spare the dying</i> cantrip, has a range of 30ft and is a bonus action.</description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_SPARE_THE_DYING" spellcasting="Cleric" />
+		</rules>
+	</element>
+	<element name="Eyes of the Grave" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_EYES_OF_THE_GRAVE">
+		<description>
+			<p>At lst level, you gain the ability to occasionally sense the presence of the undead, whose existence is an insult to the natural cycle of life. As an action, you can open your awareness to magically detect undead. Until the end of your next turn, you know the location of any undead within 60 feet of you that isn’t behind total cover and that isn’t protected from divination magic. This sense doesn’t tell you anything about a creature's capabilities or identity.</p>
+			<p class="indent">You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.</p>
+		</description>
+		<sheet>
+			<description>{{wisdom:modifier}} times per long rest, as an action you know the location of any undead within 60 feet of you that isn’t behind total cover and that isn’t protected from divination magic.</description>
+		</sheet>
+	</element>
+	<element name="Channel Divinity: Path to the Grave" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_CD_PATH_TO_THE_GRAVE">
+		<description>
+			<p>Starting at 2nd level, you can use your Channel Divinity to mark another creature’s life force for termination.</p>
+			<p class="indent">As an action, you choose one creature you can see within 30 feet of you, cursing it until the end of your next turn. The next time you or an ally of yours hits the cursed creature with an attack, the creature has vulnerability to all of that attack's damage, and then the curse ends.</p>
+		</description>
+		<sheet alt="Path to the Grave" action="Action" usage="Channel Divinity">
+			<description>Choose one creature you can see within 30ft, and curse it until the end of your next turn. The next time you or an ally of yours hits the cursed creature with an attack, the creature has vulnerability to all of that attack's damage, and then the curse ends.</description>
+		</sheet>
+	</element>
+	<element name="Sentinel at Death's Door" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_SENTINEL_AT_DEATHS_DOOR">
+		<description>
+			<p>At 6th level, you gain the ability to impede death’s progress. As a reaction when you or a creature you can see within 30 feet of you suffers a critical hit, you can turn that hit into a normal hit. Any effects triggered by a critical hit are canceled. You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.</p>
+		</description>
+		<sheet action="Reaction">
+			<description>When you or a creature you can see within 30ft of you suffers a critical hit, turn that hit into a normal hit. ({{wisdom:modifier}}/day)</description>
+		</sheet>
+	</element>
+	<element name="Potent Spellcasting" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
+			<p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
+		</description>
+		<sheet>
+			<description>Add {{wisdom:modifier}} to damage dealt with a cleric cantrip.</description>
+		</sheet>
+	</element>
+	<element name="Keeper of Souls" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_GRAVE_DOMAIN_KEEPER_OF_SOULS">
+		<description>
+			<p>Starting at 17th level. you can seize a trace of vitality from a parting soul and use it to heal the living. When an enemy you can see dies within 60 feet of you, you or one creature of your choice that is within 60 feet of you regains hit points equal to the enemy’s number of Hit Dice. You can use this feature only if you aren’t incapacitated. Once you use it, you can't do so again until the start of your next turn.</p>
+		</description>
+		<sheet>
+			<description>Once per turn, when an enemy you can see dies within 60 feet of you, you or one creature of your choice that is within 60 feet of you regains hit points equal to the enemy’s number of Hit Dice.</description>
+		</sheet>
+	</element>
 </elements>

--- a/unearthed-arcana/2015/20150803.xml
+++ b/unearthed-arcana/2015/20150803.xml
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana: Modern Magic</name>
 		<description>When the fifth edition Dungeon Master’s Guide was released in 2014, two pages in chapter 9, “Dungeon Master’s Workshop,” attracted a lot of attention. Those pages covered the rules for using firearms and explosives, an addition that allowed DMs to introduce modern and alien weaponry into the D&amp;D world, as in the classic adventure Expedition to the Barrier Peaks.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana/modern-magic">Wizards of the Coast</author>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="20150803.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/2015/20150803.xml" />
 		</update>
 	</info>
@@ -135,6 +135,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Unearthed Arcana: Modern Magic" id="ID_WOTC_UA20150803_ARCHETYPE_FEATURE_CITY_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, the cleric gains the ability to infuse his or weapon strikes with psychic energy borrowed from the citizens of your city. Once on each of the cleric's turns when he or she hits a creature with a weapon attack, the cleric can cause the attack to deal an extra 1d8 psychic damage to the target. When the cleric reaches 14th level, the extra damage increases to 2d8.</p>
 		</description>

--- a/unearthed-arcana/2016/20161121.xml
+++ b/unearthed-arcana/2016/20161121.xml
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana: Cleric: Divine Domains</name>
 		<description>Clerics are blessed with new Divine Domain options in this week's Unearthed Arcana: the domains of the Forge, the Grave, and Protection. We invite you to read their descriptions, make characters with them, and see whether you like them.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana/cleric-divine-domains">Wizards of the Coast</author>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="20161121.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/2016/20161121.xml" />
 		</update>
 	</info>
@@ -111,6 +111,7 @@
 		</sheet>
 	</element> 
 	<element name="Divine Strike" type="Archetype Feature" source="Unearthed Arcana: Cleric: Divine Domains" id="ID_WOTC_UA20161121_ARCHETYPE_FEATURE_PROTECTION_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 radiant damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>

--- a/unearthed-arcana/2018/20180409.xml
+++ b/unearthed-arcana/2018/20180409.xml
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana: Order Domain</name>
 		<description>Today we present a new playtest option for clerics: the Order Domain. An early draft of it appeared on the Twitch show The Mike Mearls Happy Fun Hour. We’ve refined that draft into the version available here.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana/order-domain">Wizards of the Coast</author>
-		<update version="0.0.6">
+		<update version="0.0.7">
 			<file name="20180409.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/2018/20180409.xml" />
 		</update>
 	</info>
@@ -123,6 +123,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Unearthed Arcana: Order Domain" id="ID_WOTC_UA_ARCHETYPE_FEATURE_ORDER_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 force damage to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
 		</description>

--- a/unearthed-arcana/2019/20191003.xml
+++ b/unearthed-arcana/2019/20191003.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name>Unearthed Arcana: Cleric, Druid, and Wizard</name>
-		<update version="0.0.5">
+		<update version="0.0.6">
 			<file name="20191003.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/2019/20191003.xml" />
 		</update>
 	</info>		
@@ -147,6 +147,7 @@
 		</sheet>
 	</element>
 	<element name="Divine Strike" type="Archetype Feature" source="Unearthed Arcana: Cleric, Druid, and Wizard" id="ID_WOTC_UA20191003_ARCHETYPE_FEATURE_TWILIGHT_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p><em>8th-level Twilight Domain feature</em></p>
 			<p>You gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 psychic damage. When you reach 14th level, the extra damage increases to 2d8.</p>

--- a/unearthed-arcana/2020/20200206.xml
+++ b/unearthed-arcana/2020/20200206.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name>Unearthed Arcana: Subclasses, Part 2</name>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="20200206.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/2020/20200206.xml" />
 		</update>
 	</info>
@@ -420,6 +420,7 @@
 		</sheet>
 	</element>
 	<element name="Potent Spellcasting" type="Archetype Feature" source="Unearthed Arcana: Subclasses, Part 2" id="ID_WOTC_UA20200206_ARCHETYPE_FEATURE_UNITY_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
 		<description>
 			<p><em>8th-level Unity Domain feature</em></p>
 			<p>You add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>

--- a/unearthed-arcana/planeshift/amonkhet/cleric-ambition.xml
+++ b/unearthed-arcana/planeshift/amonkhet/cleric-ambition.xml
@@ -1,118 +1,119 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-    <info>
-        <name>Planeshift Amonkhet: Ambition Domain</name>
-        <description>Bontu: Ambition Domain for Clerics from Planeshift Amonkhet</description>
-        <author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
-        <update version="0.0.3">
-            <file name="cleric-ambition.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-ambition.xml" />
-        </update>
-    </info>
+	<info>
+		<name>Planeshift Amonkhet: Ambition Domain</name>
+		<description>Bontu: Ambition Domain for Clerics from Planeshift Amonkhet</description>
+		<author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
+		<update version="0.0.4">
+			<file name="cleric-ambition.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-ambition.xml" />
+		</update>
+	</info>
 
-    <element name="Ambition Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_AMBITION">
-        <supports>Divine Domain</supports>
-        <description>
-            <p>Bontu has fully embraced this dictum, and though she expends little effort in teaching it, she surely leads by example. Her viziers subtly plant the seeds that flower into the ambition the God-Pharaoh desires. Through insinuation, they remind acolytes and initiates alike that achieving one’s place in the afterlife at the expense of others is not shameful, but is proof of the initiate’s determination and drive. Nothing is more important than that drive, they suggest—not the bonds of a crop, not friendship or love. Not even devotion to a deity.</p>
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_DOMAIN_SPELLS" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_WARDING_FLARE" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_INVOKE_DUPLICITY" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_CLOAK_OF_SHADOWS" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_POTENT_SPELLCASTING" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_IMPROVED_DUPLICITY" />
-        </description>
-        <setters>
-            <set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
-        </setters>
-        <sheet>
-            <description>The ambition domain is granted to those who follow the teachings of the God-Pharaoh Bontu.</description>
-        </sheet>
-        <rules>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_DOMAIN_SPELLS" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_WARDING_FLARE" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_INVOKE_DUPLICITY" level="2"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_CLOAK_OF_SHADOWS" level="6"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_POTENT_SPELLCASTING" level="8"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_IMPROVED_DUPLICITY" level="17"/>
-        </rules>
-    </element>
-    <element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_DOMAIN_SPELLS">
-        <description>
-            <p>You gain domain spells at the cleric levels listed in the Ambition Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-            <h5>AMBITION Domain Spells</h5>
-            <table>
-                <thead>
-                    <tr><td>Cleric Level</td><td>Spells</td></tr>
-                </thead>
-                <tr><td>1st</td><td><em>bane, disguise self</em></td></tr>
-                <tr><td>3rd</td><td><em>mirror image, ray of enfeeblement</em></td></tr>
-                <tr><td>5th</td><td><em>bestow curse, vampiric touch</em></td></tr>
-                <tr><td>7th</td><td><em>death ward, dimension door</em></td></tr>
-                <tr><td>9th</td><td><em>dominate person, modify memory</em></td></tr>
-            </table>
-        </description>
-        <sheet display="false">
-            <description></description>
-        </sheet>
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_BANE" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DISGUISE_SELF" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_MIRROR_IMAGE" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_RAY_OF_ENFEEBLEMENT" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_BESTOW_CURSE" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_VAMPIRIC_TOUCH" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DEATH_WARD" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DIMENSION_DOOR" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DOMINATE_PERSON" level="9" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_MODIFY_MEMORY" level="9" spellcasting="Cleric" prepared="true" />
-        </rules>
-    </element>
-    <element name="Warding Flare" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_WARDING_FLARE">
-        <description>
-            <p>When you choose this domain at 1st level, you can interpose divine light between yourself and an attacking enemy. When you are attacked by a creature within 30 feet of you that you can see, you can use your reaction to impose disadvantage on the attack roll, causing light to flare before the attacker before it hits or misses. An attacker that can’t be blinded is immune to this feature.</p>
-            <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest.</p>
-        </description>
-        <sheet usage="{{warding flare:usage}}/Long Rest">
-            <description>When you are attacked by someone within 30 ft of you which you can see you can use your reaction to impose disadvantage on the attack. Creatures immune to the blinded condition are immune to this effect.</description>
-        </sheet>
+	<element name="Ambition Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_AMBITION">
+		<supports>Divine Domain</supports>
+		<description>
+			<p>Bontu has fully embraced this dictum, and though she expends little effort in teaching it, she surely leads by example. Her viziers subtly plant the seeds that flower into the ambition the God-Pharaoh desires. Through insinuation, they remind acolytes and initiates alike that achieving one’s place in the afterlife at the expense of others is not shameful, but is proof of the initiate’s determination and drive. Nothing is more important than that drive, they suggest—not the bonds of a crop, not friendship or love. Not even devotion to a deity.</p>
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_WARDING_FLARE" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_INVOKE_DUPLICITY" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_CLOAK_OF_SHADOWS" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_POTENT_SPELLCASTING" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_IMPROVED_DUPLICITY" />
+		</description>
+		<setters>
+			<set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
+		</setters>
+		<sheet>
+			<description>The ambition domain is granted to those who follow the teachings of the God-Pharaoh Bontu.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_WARDING_FLARE" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_INVOKE_DUPLICITY" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_CLOAK_OF_SHADOWS" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_POTENT_SPELLCASTING" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_IMPROVED_DUPLICITY" level="17"/>
+		</rules>
+	</element>
+	<element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_DOMAIN_SPELLS">
+		<description>
+			<p>You gain domain spells at the cleric levels listed in the Ambition Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+			<h5>AMBITION Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>bane, disguise self</em></td></tr>
+				<tr><td>3rd</td><td><em>mirror image, ray of enfeeblement</em></td></tr>
+				<tr><td>5th</td><td><em>bestow curse, vampiric touch</em></td></tr>
+				<tr><td>7th</td><td><em>death ward, dimension door</em></td></tr>
+				<tr><td>9th</td><td><em>dominate person, modify memory</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_BANE" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DISGUISE_SELF" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_MIRROR_IMAGE" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_RAY_OF_ENFEEBLEMENT" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_BESTOW_CURSE" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_VAMPIRIC_TOUCH" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DEATH_WARD" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DIMENSION_DOOR" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DOMINATE_PERSON" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_MODIFY_MEMORY" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element>
+	<element name="Warding Flare" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_WARDING_FLARE">
+		<description>
+			<p>When you choose this domain at 1st level, you can interpose divine light between yourself and an attacking enemy. When you are attacked by a creature within 30 feet of you that you can see, you can use your reaction to impose disadvantage on the attack roll, causing light to flare before the attacker before it hits or misses. An attacker that can’t be blinded is immune to this feature.</p>
+			<p class="indent">You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest.</p>
+		</description>
+		<sheet usage="{{warding flare:usage}}/Long Rest">
+			<description>When you are attacked by someone within 30 ft of you which you can see you can use your reaction to impose disadvantage on the attack. Creatures immune to the blinded condition are immune to this effect.</description>
+		</sheet>
 		<rules>
 			<stat name="warding flare:usage" value="1" bonus="warding flare" />
 			<stat name="warding flare:usage" value="wisdom:modifier" bonus="warding flare" />
 		</rules>
-    </element>
-    <element name="Channel Divinity: Invoke Duplicity" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_INVOKE_DUPLICITY">
-        <description>
-            <p>Starting at 2nd level, you can use your Channel Divinity to create an illusory duplicate of yourself.</p>
-            <p class="indent">As an action, you create a perfect illusion of yourself that lasts for 1 minute, or until you lose your concentration (as if you were concentrating on a spell). The illusion appears in an unoccupied space that you can see within 30 feet of you. As a bonus action on your turn, you can move the illusion up to 30 feet to a space you can see, but it must remain within 120 feet of you.</p>
-            <p class="indent">For the duration, you can cast spells as though you were in the illusion’s space, but you must use your own senses. Additionally, when both you and your illusion are within 5 feet of a creature that can see the illusion, you have advantage on attack rolls against that creature, given how distracting the illusion is to the target.</p>
-        </description>
-        <sheet alt="Invoke Duplicity" action="Action" usage="Channel Divinity">
-            <description>Summon an illusion of you for 1 min. As a bonus action you can move this illusion 30 ft up to a range of 120 ft. You can cast spells as if you're on the illusions space and if you're within 5 ft of your illusion you have advatange on attack rolls against any creatures that can see both you and your illusion.</description>
-            <description level="17">Summon up to four illusions of you for 1 min. As a bonus action you can move any number of illusion 30 ft up to a range of 120 ft. You can cast spells as if you're on the illusions space and if you're within 5 ft of any of your illusion you have advatange on attack rolls against any creatures that can see both you and your illusions.</description>
-        </sheet>
-    </element>
-    <element name="Channel Divinity: Cloak of Shadows" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_CLOAK_OF_SHADOWS">
-        <description>
-            <p>Starting at 6th level, you can use your Channel Divinity to vanish. As an action, you become invisible until the end of your next turn. You become visible if you attack or cast a spell.</p>
-        </description>
-        <sheet alt="Cloak of Shadows" action="Action" usage="Channel Divinity">
-            <description>You become invisible until the end of your next turn. You become visible if you attack or cast a spell.</description>
-        </sheet>
-    </element>
-    <element name="Potent Spellcasting" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_POTENT_SPELLCASTING">
-        <description>
-            <p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
-        </description>
-        <sheet>
-            <description>Cleric cantrips deal an additional {{wisdom:modifier}} damage.</description>
-        </sheet>
-    </element>
-    <element name="Improved Duplicity" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_IMPROVED_DUPLICITY">
-        <description>
-            <p>At 17th level, you can create up to four duplicates of yourself, instead of one, when you use Invoke Duplicity. As a bonus action on your turn, you can move any number of them up to 30 feet, to a maximum range of 120 feet.</p>
-        </description>
-        <sheet display="false">
-            <description/>
-        </sheet>
-    </element>
+	</element>
+	<element name="Channel Divinity: Invoke Duplicity" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_INVOKE_DUPLICITY">
+		<description>
+			<p>Starting at 2nd level, you can use your Channel Divinity to create an illusory duplicate of yourself.</p>
+			<p class="indent">As an action, you create a perfect illusion of yourself that lasts for 1 minute, or until you lose your concentration (as if you were concentrating on a spell). The illusion appears in an unoccupied space that you can see within 30 feet of you. As a bonus action on your turn, you can move the illusion up to 30 feet to a space you can see, but it must remain within 120 feet of you.</p>
+			<p class="indent">For the duration, you can cast spells as though you were in the illusion’s space, but you must use your own senses. Additionally, when both you and your illusion are within 5 feet of a creature that can see the illusion, you have advantage on attack rolls against that creature, given how distracting the illusion is to the target.</p>
+		</description>
+		<sheet alt="Invoke Duplicity" action="Action" usage="Channel Divinity">
+			<description>Summon an illusion of you for 1 min. As a bonus action you can move this illusion 30 ft up to a range of 120 ft. You can cast spells as if you're on the illusions space and if you're within 5 ft of your illusion you have advatange on attack rolls against any creatures that can see both you and your illusion.</description>
+			<description level="17">Summon up to four illusions of you for 1 min. As a bonus action you can move any number of illusion 30 ft up to a range of 120 ft. You can cast spells as if you're on the illusions space and if you're within 5 ft of any of your illusion you have advatange on attack rolls against any creatures that can see both you and your illusions.</description>
+		</sheet>
+	</element>
+	<element name="Channel Divinity: Cloak of Shadows" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_CD_CLOAK_OF_SHADOWS">
+		<description>
+			<p>Starting at 6th level, you can use your Channel Divinity to vanish. As an action, you become invisible until the end of your next turn. You become visible if you attack or cast a spell.</p>
+		</description>
+		<sheet alt="Cloak of Shadows" action="Action" usage="Channel Divinity">
+			<description>You become invisible until the end of your next turn. You become visible if you attack or cast a spell.</description>
+		</sheet>
+	</element>
+	<element name="Potent Spellcasting" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_POTENT_SPELLCASTING">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
+			<p>Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip.</p>
+		</description>
+		<sheet>
+			<description>Cleric cantrips deal an additional {{wisdom:modifier}} damage.</description>
+		</sheet>
+	</element>
+	<element name="Improved Duplicity" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_AMBITION_DOMAIN_IMPROVED_DUPLICITY">
+		<description>
+			<p>At 17th level, you can create up to four duplicates of yourself, instead of one, when you use Invoke Duplicity. As a bonus action on your turn, you can move any number of them up to 30 feet, to a maximum range of 120 feet.</p>
+		</description>
+		<sheet display="false">
+			<description/>
+		</sheet>
+	</element>
 
 </elements>

--- a/unearthed-arcana/planeshift/amonkhet/cleric-solidarity.xml
+++ b/unearthed-arcana/planeshift/amonkhet/cleric-solidarity.xml
@@ -1,134 +1,134 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-    <info>
-        <name>Planeshift Amonkhet: Solidarity Domain</name>
-        <description>Hazoret: Solidarity Domain for Clerics from Planeshift Amonkhet</description>
-        <author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
-        <update version="0.0.3">
-            <file name="cleric-solidarity.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-solidarity.xml" />
-        </update>
-    </info>
+	<info>
+		<name>Planeshift Amonkhet: Solidarity Domain</name>
+		<description>Hazoret: Solidarity Domain for Clerics from Planeshift Amonkhet</description>
+		<author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
+		<update version="0.0.4">
+			<file name="cleric-solidarity.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-solidarity.xml" />
+		</update>
+	</info>
 
-
-    <element name="Solidarity Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_SOLIDARITY">
-        <supports>Divine Domain</supports>
-        <description>
-            <p>The God-Pharaoh expects those he welcomes into the afterlife to desire it above all other pleasures and achievements, and for them to show their dedication, passion, and fervor through their actions. Hazoret is charged with cultivating this Solidarity in the initiates who come under her care, and she has undertaken the task with appropriate enthusiasm. She recognizes, however, that the best way to teach Solidarity is by demonstrating it.</p>
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DOMAIN_SPELLS" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_BONUS_PROFICIENCIES" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SOLIDARITYS_ACTION" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_PRESERVE_LIFE" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_OKETRAS_BLESSING" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DIVINE_STRIKE" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SUPREME_HEALING" />
-        </description>
-        <setters>
-            <set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
-        </setters>
-        <sheet>
-            <description>The Solidarity domain is granted to those who follow the teachings of the God-Pharaoh Oketra.</description>
-        </sheet>
-        <rules>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DOMAIN_SPELLS" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SOLIDARITYS_ACTION" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_PRESERVE_LIFE" level="2"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_OKETRAS_BLESSING" level="6"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DIVINE_STRIKE" level="8"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SUPREME_HEALING" level="17"/>
-        </rules>
-    </element>
-    <element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DOMAIN_SPELLS">
-        <description>
-            <p>You gain domain spells at the cleric levels listed in the Solidarity Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-            <h5>Solidarity Domain Spells</h5>
-            <table>
-                <thead>
-                    <tr><td>Cleric Level</td><td>Spells</td></tr>
-                </thead>
-                <tr><td>1st</td><td><em>bless, guiding bolt</em></td></tr>
-                <tr><td>3rd</td><td><em>aid, warding bond</em></td></tr>
-                <tr><td>5th</td><td><em>beacon of hope, crusader’s mantle</em></td></tr>
-                <tr><td>7th</td><td><em>aura of life, guardian of faith</em></td></tr>
-                <tr><td>9th</td><td><em>circle of power, mass cure wounds</em></td></tr>
-            </table>
-        </description>
-        <sheet display="false">
-            <description></description>
-        </sheet>
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_BLESS" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_GUIDING_BOLT" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_AID" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_WARDING_BOND" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_BEACON_OF_HOPE" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_CRUSADERS_MANTLE" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_AURA_OF_LIFE" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_GUARDIAN_OF_FAITH" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_CIRCLE_OF_POWER" level="9" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_MASS_CURE_WOUNDS" level="9" spellcasting="Cleric" prepared="true" />
-        </rules>
-    </element>
-    <element name="Bonus Proficiencies" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_BONUS_PROFICIENCIES">
-        <description>
-            <p>When you choose this domain at 1st level, you gain proficiency with heavy armor.</p>
-        </description>
-        <sheet display="false">
-            <description>You gain proficiency with martial weapons and heavy armor.</description>
-        </sheet>
-        <rules>
-            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
-        </rules>
-    </element>
-    <element name="Solidarity’s Action" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SOLIDARITYS_ACTION">
-        <description>
-            <p>At 1st level, when you take the Help action to aid an ally’s attack, you can make one weapon attack as a bonus action. You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain expended uses when you finish a long rest.</p>
-            <p class="indent"></p>
-        </description>
-        <sheet usage="wisdom:modifier}}/Long Rest">
-            <description>When you take the help action you can make one attack as a bonus action.</description>
-        </sheet>
-    </element>
-    <element name="Channel Divinity: Preserve Life" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_PRESERVE_LIFE">
-        <description>
-        <p>Starting at 2nd level, you can use your Channel Divinity to heal the badly injured.</p>
-        <p class="indent">As an action, you present your holy symbol and evoke healing energy that can restore a number of hit points equal to five times your cleric level. Choose any creatures within 30 feet of you, and divide those hit points among them. This feature can restore a creature to no more than half of its hit point maximum. You can’t use this feature on an undead or a construct.</p>
-        </description>
-        <sheet alt="Preserve Life" action="Action" usage="Channel Divinity">
-        	<description>You present your holy symbol and evoke healing energy that can restore {{preserve life:hp}} hit points. Choose any creatures within 30 feet of you, and divide those hit points among them. This feature can restore a creature to no more than half of its hit point maximum. You can’t use this feature on an undead or a construct.</description>
-        </sheet>
-        <rules>
+	<element name="Solidarity Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_SOLIDARITY">
+		<supports>Divine Domain</supports>
+		<description>
+			<p>The God-Pharaoh expects those he welcomes into the afterlife to desire it above all other pleasures and achievements, and for them to show their dedication, passion, and fervor through their actions. Hazoret is charged with cultivating this Solidarity in the initiates who come under her care, and she has undertaken the task with appropriate enthusiasm. She recognizes, however, that the best way to teach Solidarity is by demonstrating it.</p>
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_BONUS_PROFICIENCIES" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SOLIDARITYS_ACTION" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_PRESERVE_LIFE" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_OKETRAS_BLESSING" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DIVINE_STRIKE" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SUPREME_HEALING" />
+		</description>
+		<setters>
+			<set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
+		</setters>
+		<sheet>
+			<description>The Solidarity domain is granted to those who follow the teachings of the God-Pharaoh Oketra.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SOLIDARITYS_ACTION" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_PRESERVE_LIFE" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_OKETRAS_BLESSING" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DIVINE_STRIKE" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SUPREME_HEALING" level="17"/>
+		</rules>
+	</element>
+	<element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DOMAIN_SPELLS">
+		<description>
+			<p>You gain domain spells at the cleric levels listed in the Solidarity Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+			<h5>Solidarity Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>bless, guiding bolt</em></td></tr>
+				<tr><td>3rd</td><td><em>aid, warding bond</em></td></tr>
+				<tr><td>5th</td><td><em>beacon of hope, crusader’s mantle</em></td></tr>
+				<tr><td>7th</td><td><em>aura of life, guardian of faith</em></td></tr>
+				<tr><td>9th</td><td><em>circle of power, mass cure wounds</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_BLESS" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_GUIDING_BOLT" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_AID" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_WARDING_BOND" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_BEACON_OF_HOPE" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_CRUSADERS_MANTLE" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_AURA_OF_LIFE" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_GUARDIAN_OF_FAITH" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_CIRCLE_OF_POWER" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_MASS_CURE_WOUNDS" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element>
+	<element name="Bonus Proficiencies" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_BONUS_PROFICIENCIES">
+		<description>
+			<p>When you choose this domain at 1st level, you gain proficiency with heavy armor.</p>
+		</description>
+		<sheet display="false">
+			<description>You gain proficiency with martial weapons and heavy armor.</description>
+		</sheet>
+		<rules>
+			<grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
+		</rules>
+	</element>
+	<element name="Solidarity’s Action" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SOLIDARITYS_ACTION">
+		<description>
+			<p>At 1st level, when you take the Help action to aid an ally’s attack, you can make one weapon attack as a bonus action. You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain expended uses when you finish a long rest.</p>
+			<p class="indent"></p>
+		</description>
+		<sheet usage="wisdom:modifier}}/Long Rest">
+			<description>When you take the help action you can make one attack as a bonus action.</description>
+		</sheet>
+	</element>
+	<element name="Channel Divinity: Preserve Life" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_PRESERVE_LIFE">
+		<description>
+		<p>Starting at 2nd level, you can use your Channel Divinity to heal the badly injured.</p>
+		<p class="indent">As an action, you present your holy symbol and evoke healing energy that can restore a number of hit points equal to five times your cleric level. Choose any creatures within 30 feet of you, and divide those hit points among them. This feature can restore a creature to no more than half of its hit point maximum. You can’t use this feature on an undead or a construct.</p>
+		</description>
+		<sheet alt="Preserve Life" action="Action" usage="Channel Divinity">
+			<description>You present your holy symbol and evoke healing energy that can restore {{preserve life:hp}} hit points. Choose any creatures within 30 feet of you, and divide those hit points among them. This feature can restore a creature to no more than half of its hit point maximum. You can’t use this feature on an undead or a construct.</description>
+		</sheet>
+		<rules>
 			<stat name="preserve life:hp" value="level:cleric" />
 			<stat name="preserve life:hp" value="level:cleric" />
 			<stat name="preserve life:hp" value="level:cleric" />
 			<stat name="preserve life:hp" value="level:cleric" />
 			<stat name="preserve life:hp" value="level:cleric" />
-        </rules>
-    </element>
-    <element name="Channel Divinity: Oketra’s Blessing" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_OKETRAS_BLESSING">
-        <description>
-            <p>At 6th level, when a creature within 30 feet of you makes an attack roll, you can use your reaction to grant that creature a +10 bonus to the roll, using your Channel Divinity. You make this choice after you see the roll, but before the DM says whether the attack hits or misses.</p>
-        </description>
-        <sheet alt="Oketra’s Blessing" action="Reaction" usage="Channel Divinity">
-            <description>When a creature within 30 feet of you makes an attack roll you can use your reaction to add +10 to that roll this can be done after the roll but before the results are revealed.</description>
-        </sheet>
-    </element>
-    <element name="Divine Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DIVINE_STRIKE">
-        <description>
-            <p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
-        </description>
-        <sheet>
-            <description>Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target.</description>
-            <description level="14">Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 of the same damage type to the target.</description>
-        </sheet>
-    </element>
-    <element name="Supreme Healing" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SUPREME_HEALING">
-        <description>
-            <p>Starting at 17th level, when you would normally roll one or more dice to restore hit points with a spell, you instead use the highest number possible for each die.</p>
-        </description>
-        <sheet>
-            <description>Healing spells that require dice rolls now heal for the maximum amount.</description>
-        </sheet>
-    </element>
+		</rules>
+	</element>
+	<element name="Channel Divinity: Oketra’s Blessing" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_CD_OKETRAS_BLESSING">
+		<description>
+			<p>At 6th level, when a creature within 30 feet of you makes an attack roll, you can use your reaction to grant that creature a +10 bonus to the roll, using your Channel Divinity. You make this choice after you see the roll, but before the DM says whether the attack hits or misses.</p>
+		</description>
+		<sheet alt="Oketra’s Blessing" action="Reaction" usage="Channel Divinity">
+			<description>When a creature within 30 feet of you makes an attack roll you can use your reaction to add +10 to that roll this can be done after the roll but before the results are revealed.</description>
+		</sheet>
+	</element>
+	<element name="Divine Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
+			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
+		</description>
+		<sheet>
+			<description>Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target.</description>
+			<description level="14">Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 of the same damage type to the target.</description>
+		</sheet>
+	</element>
+	<element name="Supreme Healing" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_SOLIDARITY_DOMAIN_SUPREME_HEALING">
+		<description>
+			<p>Starting at 17th level, when you would normally roll one or more dice to restore hit points with a spell, you instead use the highest number possible for each die.</p>
+		</description>
+		<sheet>
+			<description>Healing spells that require dice rolls now heal for the maximum amount.</description>
+		</sheet>
+	</element>
 
 </elements>

--- a/unearthed-arcana/planeshift/amonkhet/cleric-strength.xml
+++ b/unearthed-arcana/planeshift/amonkhet/cleric-strength.xml
@@ -1,131 +1,132 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-    <info>
-        <name>Planeshift Amonkhet: Strength Domain</name>
-        <description>Hazoret: Strength Domain for Clerics from Planeshift Amonkhet</description>
-        <author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
-        <update version="0.0.4">
-            <file name="cleric-strength.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-strength.xml" />
-        </update>
-    </info>
+	<info>
+		<name>Planeshift Amonkhet: Strength Domain</name>
+		<description>Hazoret: Strength Domain for Clerics from Planeshift Amonkhet</description>
+		<author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
+		<update version="0.0.5">
+			<file name="cleric-strength.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-strength.xml" />
+		</update>
+	</info>
 
 
-    <element name="Strength Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_STRENGTH">
-        <supports>Divine Domain</supports>
-        <description>
-            <p>It falls to Rhonas to instill this teaching in those who would enter the afterlife—but to his mind, the words themselves don’t matter. Strength can’t be taught. It must be built through practice and training. Rhonas demonstrates his teachings by his example, rather than by giving his students any kind of academic instruction. He welcomes the people of Naktamun to stand by the Hekma and watch him as he storms into the desert to battle the greatest horrors. He encourages them to observe his indomitable strength, for though they will never equal it, they can aspire to mimicry. He invites them to scrutinize every move and practice what they see</p>
+	<element name="Strength Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_STRENGTH">
+		<supports>Divine Domain</supports>
+		<description>
+			<p>It falls to Rhonas to instill this teaching in those who would enter the afterlife—but to his mind, the words themselves don’t matter. Strength can’t be taught. It must be built through practice and training. Rhonas demonstrates his teachings by his example, rather than by giving his students any kind of academic instruction. He welcomes the people of Naktamun to stand by the Hekma and watch him as he storms into the desert to battle the greatest horrors. He encourages them to observe his indomitable strength, for though they will never equal it, they can aspire to mimicry. He invites them to scrutinize every move and practice what they see</p>
 
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DOMAIN_SPELLS" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_BONUS_PROFICIENCIES" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_ACOLYTE_OF_STRENGTH" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_FEAT_OF_STRENGTH" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_RHONAS_BLESSING" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DIVINE_STRIKE" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_AVATAR_OF_BATTLE" />
-        </description>
-        <setters>
-            <set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
-        </setters>
-        <sheet>
-            <description>The Strength domain is granted to those who follow the teachings of the God-Pharaoh Rhonas.</description>
-        </sheet>
-        <rules>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DOMAIN_SPELLS" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_ACOLYTE_OF_STRENGTH" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_FEAT_OF_STRENGTH" level="2"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_RHONAS_BLESSING" level="6"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DIVINE_STRIKE" level="8"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_AVATAR_OF_BATTLE" level="17"/>
-        </rules>
-    </element>
-    <element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DOMAIN_SPELLS">
-        <description>
-            <p>You gain domain spells at the cleric levels listed in the Strength Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-            <h5>Strength Domain Spells</h5>
-            <table>
-                <thead>
-                    <tr><td>Cleric Level</td><td>Spells</td></tr>
-                </thead>
-                <tr><td>1st</td><td><em>divine favor, shield of faith</em></td></tr>
-                <tr><td>3rd</td><td><em>enhance ability, protection from poison</em></td></tr>
-                <tr><td>5th</td><td><em>haste, protection from energy</em></td></tr>
-                <tr><td>7th</td><td><em>dominate beast, stoneskin</em></td></tr>
-                <tr><td>9th</td><td><em>destructive wave, insect plague</em></td></tr>
-            </table>
-        </description>
-        <sheet display="false">
-            <description></description>
-        </sheet>
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_DIVINE_FAVOR" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_SHIELD_OF_FAITH" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_ENHANCE_ABILITY" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_POISON" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_HASTE" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DOMINATE_BEAST" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_STONESKIN" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DESTRUCTIVE_WAVE" level="9" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_INSECT_PLAGUE" level="9" spellcasting="Cleric" prepared="true" />
-        </rules>
-    </element>
-    <element name="Bonus Proficiencies" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_BONUS_PROFICIENCIES">
-        <description>
-            <p>When you choose this domain at 1st level, you gain proficiency with heavy armor.</p>
-        </description>
-        <sheet display="false">
-            <description>You gain proficiency with heavy armor.</description>
-        </sheet>
-        <rules>
-            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
-        </rules>
-    </element>
-    <element name="Acolyte of Strength" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_ACOLYTE_OF_STRENGTH">
-        <description>
-            <p>At 1st level, you learn one druid cantrip of your choice.</p>
-            <p class="indent">You also gain proficiency in one of the following skills of your choice: Animal Handling, Athletics, Nature, or Survival.</p>
-        </description>
-        <sheet display="false">
-            <description/>
-        </sheet>
-        <rules>
-            <select type="Spell" name="Cantrip (Acolyte of Strength)" supports="0,Druid" spellcasting="Cleric" />
-            <select type="Proficiency" name="Skill Proficiency (Acolyte of Strength)" supports="ID_PROFICIENCY_SKILL_ANIMAL_HANDLING|ID_PROFICIENCY_SKILL_ATHLETICS|ID_PROFICIENCY_SKILL_NATURE|ID_PROFICIENCY_SKILL_SURVIVAL" />
-        </rules>
-    </element>
-    <element name="Channel Divinity: Feat of Strength" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_FEAT_OF_STRENGTH">
-        <description>
-            <p>At 2nd level, you can use your Channel Divinity to enhance your physical might. When you make an attack roll, ability check, or saving throw using Strength, you can use your Channel Divinity to gain a +10 bonus to the roll. You make this choice after you see the roll, but before the DM says whether the roll succeeds or fails. </p>
-        </description>
-        <sheet alt="Feat of Strength" usage="Channel Divinity">
-            <description>When you make an attack roll/Ability check/saving throw with strength you can use add 10 to the roll before the result is revealed.</description>
-        </sheet>
-    </element>
-    <element name="Channel Divinity: Rhona’s Blessing" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_RHONAS_BLESSING">
-        <description>
-            <p>At 6th level, when a creature within 30 feet of you makes an attack roll, ability check, or saving throw using Strength, you can use your reaction to grant that creature a +10 bonus to the roll, using your Channel Divinity. You make this choice after you see the roll, but before the DM says whether the roll succeeds or fail.</p>
-        </description>
-        <sheet alt="Rhona’s Blessing" usage="Channel Divinity">
-            <description>When a creature within 30 ft of you makes an attack roll/ability check/saving throw with strength you can use your reaction to add 10 to the roll before the results are revealed.</description>
-        </sheet>
-    </element>
-    <element name="Divine Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DIVINE_STRIKE">
-        <description>
-            <p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
-        </description>
-        <sheet>
-            <description>Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target.</description>
-            <description level="14">Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 of the same damage type to the target.</description>
-        </sheet>
-    </element>
-    <element name="Avatar of Battle" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_AVATAR_OF_BATTLE">
-        <description>
-            <p>At 17th level, you gain resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks. </p>
-        </description>
-        <sheet>
-            <description>You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks.</description>
-        </sheet>
-    </element>
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_BONUS_PROFICIENCIES" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_ACOLYTE_OF_STRENGTH" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_FEAT_OF_STRENGTH" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_RHONAS_BLESSING" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DIVINE_STRIKE" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_AVATAR_OF_BATTLE" />
+		</description>
+		<setters>
+			<set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
+		</setters>
+		<sheet>
+			<description>The Strength domain is granted to those who follow the teachings of the God-Pharaoh Rhonas.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_ACOLYTE_OF_STRENGTH" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_FEAT_OF_STRENGTH" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_RHONAS_BLESSING" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DIVINE_STRIKE" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_AVATAR_OF_BATTLE" level="17"/>
+		</rules>
+	</element>
+	<element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DOMAIN_SPELLS">
+		<description>
+			<p>You gain domain spells at the cleric levels listed in the Strength Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+			<h5>Strength Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>divine favor, shield of faith</em></td></tr>
+				<tr><td>3rd</td><td><em>enhance ability, protection from poison</em></td></tr>
+				<tr><td>5th</td><td><em>haste, protection from energy</em></td></tr>
+				<tr><td>7th</td><td><em>dominate beast, stoneskin</em></td></tr>
+				<tr><td>9th</td><td><em>destructive wave, insect plague</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_DIVINE_FAVOR" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_SHIELD_OF_FAITH" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_ENHANCE_ABILITY" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_POISON" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_HASTE" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DOMINATE_BEAST" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_STONESKIN" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DESTRUCTIVE_WAVE" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_INSECT_PLAGUE" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element>
+	<element name="Bonus Proficiencies" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_BONUS_PROFICIENCIES">
+		<description>
+			<p>When you choose this domain at 1st level, you gain proficiency with heavy armor.</p>
+		</description>
+		<sheet display="false">
+			<description>You gain proficiency with heavy armor.</description>
+		</sheet>
+		<rules>
+			<grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
+		</rules>
+	</element>
+	<element name="Acolyte of Strength" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_ACOLYTE_OF_STRENGTH">
+		<description>
+			<p>At 1st level, you learn one druid cantrip of your choice.</p>
+			<p class="indent">You also gain proficiency in one of the following skills of your choice: Animal Handling, Athletics, Nature, or Survival.</p>
+		</description>
+		<sheet display="false">
+			<description/>
+		</sheet>
+		<rules>
+			<select type="Spell" name="Cantrip (Acolyte of Strength)" supports="0,Druid" spellcasting="Cleric" />
+			<select type="Proficiency" name="Skill Proficiency (Acolyte of Strength)" supports="ID_PROFICIENCY_SKILL_ANIMAL_HANDLING|ID_PROFICIENCY_SKILL_ATHLETICS|ID_PROFICIENCY_SKILL_NATURE|ID_PROFICIENCY_SKILL_SURVIVAL" />
+		</rules>
+	</element>
+	<element name="Channel Divinity: Feat of Strength" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_FEAT_OF_STRENGTH">
+		<description>
+			<p>At 2nd level, you can use your Channel Divinity to enhance your physical might. When you make an attack roll, ability check, or saving throw using Strength, you can use your Channel Divinity to gain a +10 bonus to the roll. You make this choice after you see the roll, but before the DM says whether the roll succeeds or fails. </p>
+		</description>
+		<sheet alt="Feat of Strength" usage="Channel Divinity">
+			<description>When you make an attack roll/Ability check/saving throw with strength you can use add 10 to the roll before the result is revealed.</description>
+		</sheet>
+	</element>
+	<element name="Channel Divinity: Rhona’s Blessing" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_CD_RHONAS_BLESSING">
+		<description>
+			<p>At 6th level, when a creature within 30 feet of you makes an attack roll, ability check, or saving throw using Strength, you can use your reaction to grant that creature a +10 bonus to the roll, using your Channel Divinity. You make this choice after you see the roll, but before the DM says whether the roll succeeds or fail.</p>
+		</description>
+		<sheet alt="Rhona’s Blessing" usage="Channel Divinity">
+			<description>When a creature within 30 ft of you makes an attack roll/ability check/saving throw with strength you can use your reaction to add 10 to the roll before the results are revealed.</description>
+		</sheet>
+	</element>
+	<element name="Divine Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
+			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
+		</description>
+		<sheet>
+			<description>Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target.</description>
+			<description level="14">Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 of the same damage type to the target.</description>
+		</sheet>
+	</element>
+	<element name="Avatar of Battle" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_STRENGTH_DOMAIN_AVATAR_OF_BATTLE">
+		<description>
+			<p>At 17th level, you gain resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks. </p>
+		</description>
+		<sheet>
+			<description>You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks.</description>
+		</sheet>
+	</element>
 
 </elements>

--- a/unearthed-arcana/planeshift/amonkhet/cleric-zeal.xml
+++ b/unearthed-arcana/planeshift/amonkhet/cleric-zeal.xml
@@ -1,129 +1,129 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-    <info>
-        <name>Planeshift Amonkhet: Zeal Domain</name>
-        <description>Hazoret: Zeal Domain for Clerics from Planeshift Amonkhet</description>
-        <author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
-        <update version="0.0.3">
-            <file name="cleric-zeal.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-zeal.xml" />
-        </update>
-    </info>
+	<info>
+		<name>Planeshift Amonkhet: Zeal Domain</name>
+		<description>Hazoret: Zeal Domain for Clerics from Planeshift Amonkhet</description>
+		<author url="https://media.wizards.com/2017/downloads/magic/plane-shift_amonkhet.pdf">Wizards of the Coast</author>
+		<update version="0.0.4">
+			<file name="cleric-zeal.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/unearthed-arcana/planeshift/amonkhet/cleric-zeal.xml" />
+		</update>
+	</info>
 
-    <element name="Zeal Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_ZEAL">
-        <supports>Divine Domain</supports>
-        <description>
-            <p>The God-Pharaoh expects those he welcomes into the afterlife to desire it above all other pleasures and achievements, and for them to show their dedication, passion, and fervor through their actions. Hazoret is charged with cultivating this zeal in the initiates who come under her care, and she has undertaken the task with appropriate enthusiasm. She recognizes, however, that the best way to teach zeal is by demonstrating it.</p>
-
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DOMAIN_SPELLS" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BONUS_PROFICIENCIES" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_PRIEST_OF_ZEAL" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_CD_CONSUMING_FERVOR" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_RESOUNDING_STRIKE" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DIVINE_STRIKE" />
-            <div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BLAZE_OF_GLORY" />
-        </description>
-        <setters>
-            <set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
-        </setters>
-        <sheet>
-            <description>The zeal domain is granted to those who follow the teachings of the God-Pharaoh Hazoret.</description>
-        </sheet>
-        <rules>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DOMAIN_SPELLS" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_PRIEST_OF_ZEAL" level="1"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_CD_CONSUMING_FERVOR" level="2"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_RESOUNDING_STRIKE" level="6"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DIVINE_STRIKE" level="8"/>
-            <grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BLAZE_OF_GLORY" level="17"/>
-        </rules>
-    </element>
-    <element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DOMAIN_SPELLS">
-        <description>
-            <p>You gain domain spells at the cleric levels listed in the Zeal Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-            <h5>Zeal Domain Spells</h5>
-            <table>
-                <thead>
-                    <tr><td>Cleric Level</td><td>Spells</td></tr>
-                </thead>
-                <tr><td>1st</td><td><em>searing smite, thunderous smite</em></td></tr>
-                <tr><td>3rd</td><td><em>magic weapon, shatter</em></td></tr>
-                <tr><td>5th</td><td><em>haste, fireball</em></td></tr>
-                <tr><td>7th</td><td><em>fire shield (warm shield only), freedom of movement</em></td></tr>
-                <tr><td>9th</td><td><em>destructive wave, flame strike</em></td></tr>
-            </table>
-        </description>
-        <sheet display="false">
-            <description></description>
-        </sheet>
-        <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_SEARING_SMITE" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_THUNDEROUS_SMITE" level="1" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_MAGIC_WEAPON" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_SHATTER" level="3" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_HASTE" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_FIREBALL" level="5" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_FREEDOM_OF_MOVEMENT" level="7" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_DESTRUCTIVE_WAVE" level="9" spellcasting="Cleric" prepared="true" />
-            <grant type="Spell" id="ID_PHB_SPELL_FLAME_STRIKE" level="9" spellcasting="Cleric" prepared="true" />
-        </rules>
-    </element>
-    <element name="Bonus Proficiencies" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BONUS_PROFICIENCIES">
-        <description>
-            <p>When you choose this domain at 1st level, you gain proficiency with matial weapons and heavy armor.</p>
-        </description>
-        <sheet display="false">
-            <description>You gain proficiency with martial weapons and heavy armor.</description>
-        </sheet>
-        <rules>
+	<element name="Zeal Domain" type="Archetype" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_CLERIC_ZEAL">
+		<supports>Divine Domain</supports>
+		<description>
+			<p>The God-Pharaoh expects those he welcomes into the afterlife to desire it above all other pleasures and achievements, and for them to show their dedication, passion, and fervor through their actions. Hazoret is charged with cultivating this zeal in the initiates who come under her care, and she has undertaken the task with appropriate enthusiasm. She recognizes, however, that the best way to teach zeal is by demonstrating it.</p>
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DOMAIN_SPELLS" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BONUS_PROFICIENCIES" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_PRIEST_OF_ZEAL" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_CD_CONSUMING_FERVOR" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_RESOUNDING_STRIKE" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DIVINE_STRIKE" />
+			<div element="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BLAZE_OF_GLORY" />
+		</description>
+		<setters>
+			<set name="sourceUrl">http://dnd.wizards.com/articles/features/plane-shift-amonkhet</set>
+		</setters>
+		<sheet>
+			<description>The zeal domain is granted to those who follow the teachings of the God-Pharaoh Hazoret.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DOMAIN_SPELLS" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BONUS_PROFICIENCIES" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_PRIEST_OF_ZEAL" level="1"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_CD_CONSUMING_FERVOR" level="2"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_RESOUNDING_STRIKE" level="6"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DIVINE_STRIKE" level="8"/>
+			<grant type="Archetype Feature" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BLAZE_OF_GLORY" level="17"/>
+		</rules>
+	</element>
+	<element name="Domain Spells" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DOMAIN_SPELLS">
+		<description>
+			<p>You gain domain spells at the cleric levels listed in the Zeal Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+			<h5>Zeal Domain Spells</h5>
+			<table>
+				<thead>
+					<tr><td>Cleric Level</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>1st</td><td><em>searing smite, thunderous smite</em></td></tr>
+				<tr><td>3rd</td><td><em>magic weapon, shatter</em></td></tr>
+				<tr><td>5th</td><td><em>haste, fireball</em></td></tr>
+				<tr><td>7th</td><td><em>fire shield (warm shield only), freedom of movement</em></td></tr>
+				<tr><td>9th</td><td><em>destructive wave, flame strike</em></td></tr>
+			</table>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<grant type="Spell" id="ID_PHB_SPELL_SEARING_SMITE" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_THUNDEROUS_SMITE" level="1" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_MAGIC_WEAPON" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_SHATTER" level="3" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_HASTE" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_FIREBALL" level="5" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_FIRE_SHIELD" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_FREEDOM_OF_MOVEMENT" level="7" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_DESTRUCTIVE_WAVE" level="9" spellcasting="Cleric" prepared="true" />
+			<grant type="Spell" id="ID_PHB_SPELL_FLAME_STRIKE" level="9" spellcasting="Cleric" prepared="true" />
+		</rules>
+	</element>
+	<element name="Bonus Proficiencies" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BONUS_PROFICIENCIES">
+		<description>
+			<p>When you choose this domain at 1st level, you gain proficiency with matial weapons and heavy armor.</p>
+		</description>
+		<sheet display="false">
+			<description>You gain proficiency with martial weapons and heavy armor.</description>
+		</sheet>
+		<rules>
 			<grant type="Proficiency" id="ID_PROFICIENCY_WEAPON_PROFICIENCY_MARTIAL_WEAPONS" />
-            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
-        </rules>
-    </element>
-    <element name="Priest of Zeal" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_PRIEST_OF_ZEAL">
-        <description>
-            <p>From 1st level, Hazoret delivers bolts of inspiration to you while you are engaged in battle. When you use the Attack action, you can make one weapon attack as a bonus action. You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest</p>
-            <p class="indent"></p>
-        </description>
-        <sheet>
-            <description>When you use the Attack action you may make one weapon attack as a bonus action. ({{wisdom:modifier}}/LR)</description>
-        </sheet>
-    </element>
-    <element name="Channel Divinity: Consuming Fervor" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_CD_CONSUMING_FERVOR">
-        <description>
-            <p>Starting at 2nd level, you can use your Channel Divinity to channel your zeal into unchecked ferocity.</p>
-            <p class="indent">When you roll fire or thunder damage, you can use your Channel Divinity to deal maximum damage instead of rolling.</p>
-        </description>
-        <sheet alt="Consuming Fervor" usage="Channel Divinity">
-            <description>When you roll fire or thunder damage, you can use your Channel Divinity to deal maximum damage instead of rolling.</description>
-        </sheet>
-    </element>
-    <element name="Resounding Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_RESOUNDING_STRIKE">
-        <description>
-            <p>At 6th level, when you deal thunder damage to a Large or smaller creature, you can also push it up to 10 feet away from you.</p>
-        </description>
-        <sheet>
-            <description>When you deal thunder damage to a Large or smaller creature, you can also push it up to 10 feet away from you.</description>
-        </sheet>
-    </element>
-    <element name="Divine Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DIVINE_STRIKE">
-        <description>
-            <p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
-        </description>
-        <sheet>
-            <description>Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target.</description>
-            <description level="14">Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 of the same damage type to the target.</description>
-        </sheet>
-    </element>
-    <element name="Blaze of Glory" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BLAZE_OF_GLORY">
-        <description>
-            <p>Starting at 17th level, you can delay death for an instant to perform a final heroic act. </p>
-            <p class="indent">When you are reduced to 0 hit points by an attacker you can see, even if you would be killed outright, you can use your reaction to move up to your speed toward the attacker and make one melee weapon attack against it, as long as the movement brings it within your reach. You make this attack with advantage. If the attack hits, the creature takes an extra 5d10 fire damage and an extra 5d10 damage of the weapon’s type. You then fall unconscious and begin making death saving throws as normal, or you die if the damage you took would have killed you outright. Once you use this feature, you can’t use it again until you finish a long rest.</p>
-        </description>
-        <sheet>
-            <description>Once per long rest if you were to drop to 0 HP or die from an attack you can move your movement up to the attacker and make a melee attack with advantage. On a hit the target takes an additional 5d10 fire and 5d10 weapon type damage.</description>
-        </sheet>
-    </element>
+			<grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_HEAVY_ARMOR" />
+		</rules>
+	</element>
+	<element name="Priest of Zeal" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_PRIEST_OF_ZEAL">
+		<description>
+			<p>From 1st level, Hazoret delivers bolts of inspiration to you while you are engaged in battle. When you use the Attack action, you can make one weapon attack as a bonus action. You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest</p>
+			<p class="indent"></p>
+		</description>
+		<sheet>
+			<description>When you use the Attack action you may make one weapon attack as a bonus action. ({{wisdom:modifier}}/LR)</description>
+		</sheet>
+	</element>
+	<element name="Channel Divinity: Consuming Fervor" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_CD_CONSUMING_FERVOR">
+		<description>
+			<p>Starting at 2nd level, you can use your Channel Divinity to channel your zeal into unchecked ferocity.</p>
+			<p class="indent">When you roll fire or thunder damage, you can use your Channel Divinity to deal maximum damage instead of rolling.</p>
+		</description>
+		<sheet alt="Consuming Fervor" usage="Channel Divinity">
+			<description>When you roll fire or thunder damage, you can use your Channel Divinity to deal maximum damage instead of rolling.</description>
+		</sheet>
+	</element>
+	<element name="Resounding Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_RESOUNDING_STRIKE">
+		<description>
+			<p>At 6th level, when you deal thunder damage to a Large or smaller creature, you can also push it up to 10 feet away from you.</p>
+		</description>
+		<sheet>
+			<description>When you deal thunder damage to a Large or smaller creature, you can also push it up to 10 feet away from you.</description>
+		</sheet>
+	</element>
+	<element name="Divine Strike" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_DIVINE_STRIKE">
+		<requirements>!ID_INTERNAL_FEATURE_REPLACEMENT_CLERIC_DIVINE_STRIKE_OR_POTENT_SPELLCASTING</requirements>
+		<description>
+			<p>At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target. When you reach 14th level, the extra damage increases to 2d8.</p>
+		</description>
+		<sheet>
+			<description>Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 1d8 of the same damage type to the target.</description>
+			<description level="14">Once per turn when you hit a creature with a weapon attack, you can cause the attack to deal an extra 2d8 of the same damage type to the target.</description>
+		</sheet>
+	</element>
+	<element name="Blaze of Glory" type="Archetype Feature" source="Plane Shift: Amonkhet" id="ID_WOTC_PSA_ARCHETYPE_FEATURE_ZEAL_DOMAIN_BLAZE_OF_GLORY">
+		<description>
+			<p>Starting at 17th level, you can delay death for an instant to perform a final heroic act. </p>
+			<p class="indent">When you are reduced to 0 hit points by an attacker you can see, even if you would be killed outright, you can use your reaction to move up to your speed toward the attacker and make one melee weapon attack against it, as long as the movement brings it within your reach. You make this attack with advantage. If the attack hits, the creature takes an extra 5d10 fire damage and an extra 5d10 damage of the weapon’s type. You then fall unconscious and begin making death saving throws as normal, or you die if the damage you took would have killed you outright. Once you use this feature, you can’t use it again until you finish a long rest.</p>
+		</description>
+		<sheet>
+			<description>Once per long rest if you were to drop to 0 HP or die from an attack you can move your movement up to the attacker and make a melee attack with advantage. On a hit the target takes an additional 5d10 fire and 5d10 weapon type damage.</description>
+		</sheet>
+	</element>
 
 </elements>


### PR DESCRIPTION
Current progress:
- [x] — Barbarian
- [x] — Bard
- [x] — Cleric
- [x] — Druid
- [x] — Fighter
- [x] — Monk
- [x] — Paladin
- [x] — Ranger
- [x] — Rogue
- [x] — Sorcerer
- [x] — Warlock
- [x] — Wizard
- [x] — Adding requirements to non-PHB Cleric Archetypes
- [x] — change the placement of internal elements
---
Some things about this version of the OCF:
• Placement of the features on the sheet:
Sadly, OCFs are treated similarly to Feats, so most of the time you will discover that they're placed above other Class Features, that's currently impossible to fix due to app's limitations/closed-source nature.