### PR TITLE
[MISC] Add supports for spells and fix Spell Sniper Feat

### DIFF
--- a/core/players-handbook/feats.xml
+++ b/core/players-handbook/feats.xml
@@ -4,7 +4,7 @@
 		<name>Feats</name>
 		<description>Feats from the Player’s Handbook.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.1.7">
+		<update version="0.1.8">
 			<file name="feats.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/feats.xml" />
 		</update>
 	</info>
@@ -984,8 +984,7 @@
 			Your ranged spell attacks ignore half cover and three-quarters cover.</description>
 		</sheet>
 		<rules>
-			<!-- todo: supports ID_INTERNAL_SUPPORT_SPELL_ATTACK -->
-			<select type="Spell" name="Spell Sniper" supports="0,(Bard||Cleric||Druid||Sorcerer||Warlock||Wizard)" />
+			<select type="Spell" name="Spell Sniper" supports="0,(Bard||Cleric||Druid||Sorcerer||Warlock||Wizard), Spell Attack" />
 		</rules>
 	</element>
 	<element name="Tavern Brawler" type="Feat" source="Player’s Handbook" id="ID_PHB_FEAT_TAVERNBRAWLER">

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -685,7 +685,7 @@
 		</setters>
 	</element>
 	<element name="Bigby’s Hand" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BIGBYS_HAND">
-		<supports>Wizard, Artificer, Spell Attack</supports>
+		<supports>Wizard, Artificer, Melee, Spell Attack</supports>
 		<description>
 			<p>You create a Large hand of shimmering, translucent force in an unoccupied space that you can see within range. The hand lasts for the spell’s duration, and it moves at your command, mimicking the movements of your own hand. The hand is an object that has AC 20 and hit points equal to your hit point maximum. If it drops to 0 hit points, the spell ends. It has a Strength of 26 (+8) and a Dexterity of 10 (+0). The hand doesn’t fill its space. When you cast the spell and as a bonus action on your subsequent turns, you can move the hand up to 60 feet and then cause one of the following effects with it. Clenched Fist. The hand strikes one creature or object within 5 feet of it. Make a melee spell attack for the hand using your game statistics. On a hit, the target takes 4d8 force damage. Forceful Hand. The hand attempts to push a creature within 5 feet of it in a direction you choose. Make a check with the hand’s Strength contested by the Strength (Athletics) check of the target. If the target is Medium or smaller, you have advantage on the check. If you succeed, the hand pushes the target up to 5 feet plus a number of feet equal to five times your spellcasting ability modifier. The hand moves with the target to remain within 5 feet of it. Grasping Hand. The hand attempts to grapple a Huge or smaller creature within 5 feet of it. You use the hand’s Strength score to resolve the grapple. If the target is Medium or smaller, you have advantage on the check. While the hand is grappling the target, you can use a bonus action to have the hand crush it. When you do so, the target takes bludgeoning damage equal to 2d6 + your spellcasting ability modifier. Interposing Hand. The hand interposes itself between you and a creature you choose until you give the hand a different command. The hand moves to stay between you and the target, providing you with half cover against the target. The target can’t move through the hand’s space if its Strength score is less than or equal to the hand’s Strength score. If its Strength score is higher than the hand’s Strength score, the target can move toward you through the hand’s space, but that space is difficult terrain for the target.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, the damage from the clenched fist option increases by 2d8 and the damage from the grasping hand increases by 2d6 for each slot level above 5th.</p>
@@ -998,7 +998,7 @@
 		</setters>
 	</element>
 	<element name="Chill Touch" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CHILL_TOUCH">
-		<supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
+		<supports>Sorcerer, Warlock, Wizard, Ranged, Spell Attack</supports>
 		<description>
 			<p>You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can’t regain hit points until the start of your next turn. Until then, the hand clings to the target. If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn. This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -1018,7 +1018,7 @@
 		</setters>
 	</element>
 	<element name="Chromatic Orb" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CHROMATIC_ORB">
-		<supports>Sorcerer, Wizard, Spell Attack</supports>
+		<supports>Sorcerer, Wizard, Ranged, Spell Attack</supports>
 		<description>
 			<p>You hurl a 4-inch-diameter sphere of energy at a creature that you can see within range. You choose acid, cold, fire, lightning, poison, or thunder for the type of orb you create, and then make a ranged spell attack against the target. If the attack hits, the creature takes 3d8 damage of the type you choose.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.</p>
@@ -1584,7 +1584,7 @@
 		</setters>
 	</element>
 	<element name="Contagion" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONTAGION">
-		<supports>Cleric, Druid, Spell Attack, Spell Saving Throw</supports>
+		<supports>Cleric, Druid, Melee, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>Your touch inflicts disease. Make a melee spell attack against a creature within your reach. On a hit, the target is poisoned.</p>
 			<p class="indent">At the end of each of the poisoned target’s turns, the target must make a Constitution saving throw. If the target succeeds on three of these saves, it is no longer poisoned, and the spell ends. If the target fails three of these saves, the target is no longer poisoned, but choose one of the diseases below. The target is subjected to the chosen disease for the spell’s duration.</p> 
@@ -2228,7 +2228,7 @@
 		</setters>
 	</element>
 	<element name="Dispel Evil and Good" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DISPEL_EVIL_AND_GOOD">
-		<supports>Cleric, Paladin, Spell Attack, Spell Saving Throw</supports>
+		<supports>Cleric, Paladin, Melee, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>Shimmering energy surrounds and protects you from fey, undead, and creatures originating from beyond the Material Plane. For the duration, celestials, elementals, fey, fiends, and undead have disadvantage on attack rolls against you. You can end the spell early by using either of the following special functions. Break  Enchantment. As your action, you touch a creature you can reach that is charmed, frightened, or possessed by a celestial, an elemental, a fey, a fiend, or an undead. The creature you touch is no longer charmed, frightened, or possessed by such creatures. Dismissal. As your action, make a melee spell attack against a celestial, an elemental, a fey, a fiend, or an undead you can reach. On a hit, you attempt to drive the creature back to its home plane. The creature must succeed on a Charisma saving throw or be sent back to its home plane (if it isn’t there already). If they aren’t on their home plane, undead are sent to the Shadowfell, and fey are sent to the Feywild.</p>
 		</description>
@@ -2518,7 +2518,7 @@
 		</setters>
 	</element>
 	<element name="Eldritch Blast" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ELDRITCH_BLAST">
-		<supports>Warlock, Spell Attack</supports>
+		<supports>Warlock, Ranged, Spell Attack</supports>
 		<description>
 			<p>A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage.</p>
 		<p class="indent">The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. you can direct the beams at the same target or at different ones. Make a separate attack roll for each beam.</p>
@@ -3015,7 +3015,7 @@
 		</setters>
 	</element>
 	<element name="Fire Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FIRE_BOLT">
-		<supports>Sorcerer, Wizard, Artificer, Spell Attack</supports>
+		<supports>Sorcerer, Wizard, Artificer, Ranged, Spell Attack</supports>
 		<description>
 			<p>You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn’t being worn or carried.</p>
 			<p class="indent">This spell’s damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</p>
@@ -3099,7 +3099,7 @@
 		</setters>
 	</element>
 	<element name="Flame Blade" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FLAME_BLADE">
-		<supports>Druid, Spell Attack</supports>
+		<supports>Druid, Melee, Spell Attack</supports>
 		<description>
 			<p>You evoke a fiery blade in your free hand. The blade is similar in size and shape to a scimitar, and it lasts for the duration. If you let go of the blade, it disappears, but you can evoke the blade again as a bonus action. You can use your action to make a melee spell attack with the fiery blade. On a hit, the target takes 3d6 fire damage. The flaming blade sheds bright light in a 10-foot radius and dim light for an additional 10 feet.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for every two slot levels above 2nd.</p>
@@ -3674,7 +3674,7 @@
 		</setters>
 	</element>
 	<element name="Guiding Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GUIDING_BOLT">
-		<supports>Cleric, Spell Attack</supports>
+		<supports>Cleric, Ranged, Spell Attack</supports>
 		<description>
 			<p>A flash of light streaks toward a creature of your choice within range. Make a ranged spell attack against the target. On a hit, the target takes 4d6 radiant damage, and the next attack roll made against this target before the end of your next turn has advantage, thanks to the mystical dim light glittering on the target until then.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -4190,7 +4190,7 @@
 		</setters>
 	</element>
 	<element name="Inflict Wounds" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_INFLICT_WOUNDS">
-		<supports>Cleric, Spell Attack</supports>
+		<supports>Cleric, Melee, Spell Attack</supports>
 		<description>
 			<p>Make a melee spell attack against a creature you can reach. On a hit, the target takes 3d10 necrotic damage.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d10 for each slot level above 1st.</p>
@@ -4840,7 +4840,7 @@
 		</setters>
 	</element>
 	<element name="Melf’s Acid Arrow" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MELFS_ACID_ARROW">
-		<supports>Wizard, Spell Attack</supports>
+		<supports>Wizard, Ranged, Spell Attack</supports>
 		<description>
 			<p>A shimmering green arrow streaks toward a target within range and bursts in a spray of acid. Make a ranged spell attack against the target. On a hit, the target takes 4d4 acid damage immediately and 2d4 acid damage at the end of its next turn. On a miss, the arrow splashes the target with acid for half as much of the initial damage and no damage at the end of its next turn.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage (both initial and later) increases by 1d4 for each slot level above 2nd.</p>
@@ -5162,7 +5162,7 @@
 		</setters>
 	</element>
 	<element name="Mordenkainen’s Sword" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MORDENKAINENS_SWORD">
-		<supports>Bard, Wizard, Spell Attack</supports>
+		<supports>Bard, Wizard, Melee, Spell Attack</supports>
 		<description>
 			<p>You create a sword-shaped plane of force that hovers within range. It lasts for the duration.</p>
 			<p>When the sword appears, you make a melee spell attack against a target of your choice within 5 feet of the sword. On a hit, the target takes 3d10 force damage. Until the spell ends, you can use a bonus action on each of your turns to move the sword up to 20 feet to a spot you can see and repeat this attack against the same target or a different one.</p>
@@ -5447,7 +5447,7 @@
 		</setters>
 	</element>
 	<element name="Plane Shift" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PLANE_SHIFT">
-		<supports>Cleric, Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
+		<supports>Cleric, Druid, Sorcerer, Warlock, Wizard, Melee, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>You and up to eight willing creatures who link hands in a circle are transported to a different plane of existence. You can specify a target destination in general terms, such as the City of Brass on the Elemental Plane of Fire or the palace of Dispater on the second level of the Nine Hells, and you appear in or near that destination. If you are trying to reach the City of Brass, for example, you might arrive in its Street of Steel, before its Gate of Ashes, or looking at the city from across the Sea of Fire, at the DM’s discretion.</p>
 			<p class="indent">Alternatively, if you know the sigil sequence of a teleportation circle on another plane of existence, this spell can take you to that circle. If the teleportation circle is too small to hold all the creatures you transported, they appear in the closest unoccupied spaces next to the circle.</p>
@@ -5705,7 +5705,7 @@
 		</setters>
 	</element>
 	<element name="Produce Flame" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PRODUCE_FLAME">
-		<supports>Druid, Spell Attack</supports>
+		<supports>Druid, Ranged, Spell Attack</supports>
 		<description>
 			<p>A flickering flame appears in your hand. The flame remains there for the duration and harms neither you nor your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet. The spell ends if you dismiss it as an action or if you cast it again. You can also attack with the flame, although doing so ends the spell. When you cast this spell, or as an action on a later turn, you can hurl the flame at a creature within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 fire damage. This spell’s damage increases by 1d8 when you reach 5th level (2d8),  11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -5885,7 +5885,7 @@
 		</setters>
 	</element>
 	<element name="Ray of Enfeeblement" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_RAY_OF_ENFEEBLEMENT">
-		<supports>Warlock, Wizard, Spell Saving Throw</supports>
+		<supports>Warlock, Wizard, Ranged, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>A black beam of enervating energy springs from your finger toward a creature within range. Make a ranged spell attack against the target. On a hit, the target deals only half damage with weapon attacks that use Strength until the spell ends. At the end of each of the target’s turns, it can make a Constitution saving throw against the spell. On a success, the spell ends.</p>
 		</description>
@@ -5905,7 +5905,7 @@
 		</setters>
 	</element>
 	<element name="Ray of Frost" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_RAY_OF_FROST">
-		<supports>Sorcerer, Wizard, Artificer, Spell Attack</supports>
+		<supports>Sorcerer, Wizard, Artificer, Ranged, Spell Attack</supports>
 		<description>
 			<p>A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn. The spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -5925,7 +5925,7 @@
 		</setters>
 	</element>
 	<element name="Ray of Sickness" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_RAY_OF_SICKNESS">
-		<supports>Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
+		<supports>Sorcerer, Wizard, Ranged, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>A ray of sickening greenish energy lashes out toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and must make a Constitution saving throw. On a failed save, it is also poisoned until the end of your next turn.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.</p>
@@ -6166,7 +6166,7 @@
 		</setters>
 	</element>
 	<element name="Scorching Ray" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SCORCHING_RAY">
-		<supports>Sorcerer, Wizard, Spell Attack</supports>
+		<supports>Sorcerer, Wizard, Ranged, Spell Attack</supports>
 		<description>
 			<p>You create three rays of fire and hurl them at targets within range. You can hurl them at one target or several. Make a ranged spell attack for each ray. On a hit, the target takes 2d6 fire damage.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, you create one additional ray for each slot level above 2nd.</p>
@@ -6409,7 +6409,7 @@
 		</setters>
 	</element>
 	<element name="Shocking Grasp" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SHOCKING_GRASP">
-		<supports>Sorcerer, Wizard, Artificer, Spell Attack</supports>
+		<supports>Sorcerer, Wizard, Artificer, Melee, Spell Attack</supports>
 		<description>
 			<p>Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can’t take reactions until the start of its next turn.</p>
 			<p class="indent">The spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
@@ -6704,7 +6704,7 @@
 		</setters>
 	</element>
 	<element name="Spiritual Weapon" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SPIRITUAL_WEAPON">
-		<supports>Cleric, Spell Attack</supports>
+		<supports>Cleric, Melee, Spell Attack</supports>
 		<description>
 			<p>You create a floating, spectral weapon within range that lasts for the duration or until you cast this spell again. When you cast the spell, you can make a melee spell attack against a creature within 5 feet of the weapon. On a hit, the target takes force damage equal to 1d8 + your spellcasting ability modifier. As a bonus action on your turn, you can move the weapon up to 20 feet and repeat the attack against a creature within 5 feet of it. The weapon can take whatever form you choose. Clerics of deities who are associated with a particular weapon (as St. Cuthbert is known for his mace and Thor for his hammer) make this spell’s effect resemble that weapon.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for every two slot levels above the 2nd.</p>
@@ -7107,7 +7107,7 @@
 		</setters>
 	</element>
 	<element name="Thorn Whip" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_THORN_WHIP">
-		<supports>Druid, Artificer, Spell Attack</supports>
+		<supports>Druid, Artificer, Melee, Spell Attack</supports>
 		<description>
 			<p>You create a long, vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes 1d6 piercing damage, and if the creature is Large or smaller, you pull the creature up to 10 feet closer to you. This spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
 		</description>
@@ -7381,7 +7381,7 @@
 		</setters>
 	</element>
 	<element name="Vampiric Touch" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_VAMPIRIC_TOUCH">
-		<supports>Warlock, Wizard, Spell Attack</supports>
+		<supports>Warlock, Wizard, Melee, Spell Attack</supports>
 		<description>
 			<p>The touch of your shadow-wreathed hand can siphon force from others to heal your wounds. Make a melee spell attack against a creature within your reach. On a hit, the target takes 3d6 necrotic damage, and you regain hit points equal to half the amount of necrotic damage dealt. Until the spell ends, you can make the attack again on each of your turns as an action.  </p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for each slot level above 3rd.</p>
@@ -7715,7 +7715,7 @@
 		</setters>
 	</element>
 	<element name="Witch Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WITCH_BOLT">
-		<supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
+		<supports>Sorcerer, Warlock, Wizard, Ranged, Spell Attack</supports>
 		<description>
 			<p>A beam of crackling, blue energy lances out toward a creature within range, forming a sustained arc of lightning between you and the target. Make a ranged spell attack against that creature. On a hit, the target takes 1d12 lightning damage, and on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically. The spell ends if you use your action to do anything else. The spell also ends if the target is ever outside the spell’s range or if it has total cover from you.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the initial damage increases by 1d12 for each slot level above 1st.</p>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -6834,7 +6834,7 @@
 		<description>
 			<p>You suggest a course of activity (limited to a sentence or two) and magically influence a creature you can see within range that can hear and understand you. Creatures that can’t be charmed are immune to this effect. The suggestion must be worded in such a manner as to make the course of action sound reasonable. Asking the creature to stab itself, throw itself onto a spear, immolate itself, or do some other obviously harmful act ends the spell.</p>
 			<p class="indent">The target must make a Wisdom saving throw. On a failed save, it purses the course of action you described to the best of its ability. The suggested course of action can continue for the entire duration. If the suggested activity can be completed in a shorter time, the spell ends when the subject finishes what it was asked to do.</p>
-			<p class="indent">You can also specify conditions that will trigger a special activity during the duration. For example, you might suggest that a knight five her warhorse to the first beggar she meets.</p>
+			<p class="indent">You can also specify conditions that will trigger a special activity during the duration. For example, you might suggest that a knight give her warhorse to the first beggar she meets.</p>
 			<p class="indent">If the condition isn’t met before the spell expires, the activity isn’t preformed. If you or any of your companions damage the target, the spell ends.</p>
 		</description>
 		<setters>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -2,13 +2,13 @@
 <elements>
 	<info>
 		<name>Spells</name>
-		<update version="0.4.7">
+		<update version="0.4.8">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/spells.xml" />
 		</update>
 	</info>
 
 	<element name="Acid Splash" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ACID_SPLASH">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>You hurl a bubble of acid. Choose one creature you can see within range, or choose two creatures you can see within range that are within 5 feet of each other. A target must succeed on a Dexterity saving throw or take 1d6 acid damage.</p>
 			<p class="indent">This spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -95,7 +95,7 @@
 		</setters>
 	</element>
 	<element name="Animal Friendship" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ANIMAL_FRIENDSHIP">
-		<supports>Bard, Druid, Ranger</supports>
+		<supports>Bard, Druid, Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>This spell lets you convince a beast that you mean it no harm. Choose a beast that you can see within range. It must see and hear you. If the beast’s Intelligence is 4 or higher, the spell fails. Otherwise, the beast must succeed on a Wisdom saving throw or be charmed by you for the spell’s duration. If you or one of your companions harms the target, the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, you can affect one additional beast for each slot level above 1st.</p>
@@ -269,7 +269,7 @@
 		</setters>
 	</element>
 	<element name="Antipathy/Sympathy" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ANTIPATHY_SYMPATHY">
-		<supports>Druid, Wizard</supports>
+		<supports>Druid, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>This spell attracts or repels creatures of your choice. You target something within range, either a Huge or smaller object or creature or an area that is no larger than a 200-foot cube. Then specify a kind of intelligent creature, such as red dragons, goblins, or vampires. You invest the target with an aura that either attracts or repels the specified creatures for the duration. Choose antipathy or sympathy as the aura’s effect.</p>
 			<p class="indent"><strong><em>Antipathy.</em></strong> The enchantment causes creatures of the kind you designated to feel an intense urge to leave the area and avoid the target. When such a creature can see the target or comes within 60 feet of it, the creature must succeed on a Wisdom saving throw or become frightened. The creature remains frightened while it can see the target or is within 60 feet of it. While frightened by the target, the creature must use its movement to move to the nearest safe spot from which it can’t see the target. If the creature moves more than 60 feet from the target and can’t see it, the creature is no longer frightened, but the creature becomes frightened again if it regains sight of the target or moves within 60 feet of it.</p>
@@ -380,7 +380,7 @@
 		</setters>
 	</element>
 	<element name="Arms of Hadar" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ARMS_OF_HADAR">
-		<supports>Warlock</supports>
+		<supports>Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>You invoke the power of Hadar, the Dark Hunger. Tendrils of dark energy erupt from you and batter all creatures within 10 feet of you. Each creature in that area must make a Strength saving throw. On a failed save, a target takes 2d6 necrotic damage and can’t take reactions until its next turn. On a successful save, the creature takes half damage, but suffers no other effect.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -535,7 +535,7 @@
 		</setters>
 	</element>
 	<element name="Bane" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BANE">
-		<supports>Bard, Cleric</supports>
+		<supports>Bard, Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>Up to three creatures of your choice that you can see within range must make Charisma saving throws. Whenever a target that fails this saving throw makes an attack roll or a saving throw before the spell ends, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.</p>
@@ -576,7 +576,7 @@
 		</setters>
 	</element>
 	<element name="Banishment" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BANISHMENT">
-		<supports>Cleric, Paladin, Sorcerer, Warlock, Wizard</supports>
+		<supports>Cleric, Paladin, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to send one creature that you can see within range to another place of existence. The target must succeed on a Charisma saving throw or be banished. If the target is native to the plane of existence you’re on, you banish the target to a harmless demiplane. While there, the target is incapacitated. The target remains there until the spell ends, at which point the target reappears in the space it left or in the nearest unoccupied space if that space is occupied. If the target is native to a different plane of existence that the one you’re on, the target is banished with a faint popping noise, returning to its home plane. If the spell ends before 1 minute has passed, the target reappears in the space it left or in the nearest unoccupied space if that space is occupied. Otherwise, the target doesn’t return.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th.</p>
@@ -657,7 +657,7 @@
 		</setters>
 	</element>
 	<element name="Bestow Curse" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BESTOW_CURSE">
-		<supports>Bard, Cleric, Wizard</supports>
+		<supports>Bard, Cleric, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You touch a creature, and that creature must succeed on a Wisdom saving throw or become cursed for the duration of the spell. When you cast this spell, choose the nature of the curse from the following options:</p>
 			<ul>
@@ -685,7 +685,7 @@
 		</setters>
 	</element>
 	<element name="Bigby’s Hand" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BIGBYS_HAND">
-		<supports>Wizard, Artificer</supports>
+		<supports>Wizard, Artificer, Spell Attack</supports>
 		<description>
 			<p>You create a Large hand of shimmering, translucent force in an unoccupied space that you can see within range. The hand lasts for the spell’s duration, and it moves at your command, mimicking the movements of your own hand. The hand is an object that has AC 20 and hit points equal to your hit point maximum. If it drops to 0 hit points, the spell ends. It has a Strength of 26 (+8) and a Dexterity of 10 (+0). The hand doesn’t fill its space. When you cast the spell and as a bonus action on your subsequent turns, you can move the hand up to 60 feet and then cause one of the following effects with it. Clenched Fist. The hand strikes one creature or object within 5 feet of it. Make a melee spell attack for the hand using your game statistics. On a hit, the target takes 4d8 force damage. Forceful Hand. The hand attempts to push a creature within 5 feet of it in a direction you choose. Make a check with the hand’s Strength contested by the Strength (Athletics) check of the target. If the target is Medium or smaller, you have advantage on the check. If you succeed, the hand pushes the target up to 5 feet plus a number of feet equal to five times your spellcasting ability modifier. The hand moves with the target to remain within 5 feet of it. Grasping Hand. The hand attempts to grapple a Huge or smaller creature within 5 feet of it. You use the hand’s Strength score to resolve the grapple. If the target is Medium or smaller, you have advantage on the check. While the hand is grappling the target, you can use a bonus action to have the hand crush it. When you do so, the target takes bludgeoning damage equal to 2d6 + your spellcasting ability modifier. Interposing Hand. The hand interposes itself between you and a creature you choose until you give the hand a different command. The hand moves to stay between you and the target, providing you with half cover against the target. The target can’t move through the hand’s space if its Strength score is less than or equal to the hand’s Strength score. If its Strength score is higher than the hand’s Strength score, the target can move toward you through the hand’s space, but that space is difficult terrain for the target.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, the damage from the clenched fist option increases by 2d8 and the damage from the grasping hand increases by 2d6 for each slot level above 5th.</p>
@@ -706,7 +706,7 @@
 		</setters>
 	</element>
 	<element name="Blade Barrier" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BLADE_BARRIER">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>You create a vertical wall of whirling, razor-sharp blades made of magical energy. The wall appears within range and lasts for the duration. You can make a straight wall up to 100 feet long, 20 feet high, and 5 feet thick, or a ringed wall up to 60 feet in diameter, 20 feet high, and 5 feet thick. The wall provides three-quarters cover to creatures behind it, and its space is difficult terrain.  When a creature enters the wall’s area for the first time on a turn or starts its turn there, the creature must make a Dexterity saving throw. On a failed save, the creature takes 6d10 slashing damage. On a successful save, the creature takes half as much damage.</p>
 		</description>
@@ -767,7 +767,7 @@
 		</setters>
 	</element>
 	<element name="Blight" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BLIGHT">
-		<supports>Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Necromantic energy washes over a creature of your choice that you can see within range, draining moisture and vitality from it. The target must make a Constitution saving throw. The target takes 8d8 necrotic damage on a failed save, or half as much damage on a successful one. This spell has no effect on undead or constructs. If you target a plant creature or a magical plant, it makes the saving throw with disadvantage, and the spell deals maximum damage to it. If you target a nonmagical plant that isn’t a creature, such as a tree or shrub, it doesn’t make a saving throw</p>
 		</description>
@@ -787,7 +787,7 @@
 		</setters>
 	</element>
 	<element name="Blinding Smite" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BLINDING_SMITE">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you hit a creature with a melee weapon attack during this spell’s duration, you weapon flares with a bright light, and the attack deals an extra 3d8 radiant damage to the target. Additionally, the target must succeed on a Constitution saving throw or be blinded until the spell ends. A creature blinded by this spell makes another Constitution saving throw at the end of each of its turns. On a successful save, it is no longer blinded.</p>
 		</description>
@@ -807,7 +807,7 @@
 		</setters>
 	</element>
 	<element name="Blindness/Deafness" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BLINDNESS_DEAFNESS">
-		<supports>Bard, Cleric, Sorcerer, Wizard</supports>
+		<supports>Bard, Cleric, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You can blind or deafen a foe. Choose one creature that you can see within range to make a Constitution saving throw. If it fails, the target is either blinded or deafened (your choice) for the duration. At the end of each of its turns, the target can make a Constitution saving throw. On a success, the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd or higher, you can target one additional creature for each slot level above 2nd.</p>
@@ -889,7 +889,7 @@
 		</setters>
 	</element>
 	<element name="Burning Hands" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_BURNING_HANDS">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>As you hold your hands with thumbs touching and fingers spread, a thin sheet of flames shoots forth from your outstretched fingertips. Each creature in a 15-foot cone must make a Dexterity saving throw. A creature takes 3d6 fire damage on a failed save, or half as much damage on a successful one. The fire ignites any flammable objects in the area that aren’t being worn or carried.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -910,7 +910,7 @@
 		</setters>
 	</element>
 	<element name="Call Lightning" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CALL_LIGHTNING">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>A storm cloud appears in the shape of a cylinder that is 10 feet tall with a 60-foot radius, centered on a point you can see within range directly above you. The spell fails if you can’t see a point in the air where the storm cloud could appear (for example, if you are in a room that can’t accommodate the cloud).</p>
 			<p class="indent">When you cast the spell, choose a point you can see under the cloud. A bolt of lightning flashes down from the cloud to that point. Each creature within 5 feet of that point must make a Dexterity saving throw. A creature takes 3d10 lightning damage on a failed save, or half as much damage on a successful one. On each of your turns until the spell ends, you can use your action to call down lightning in this way again, targeting the same point or a different one.</p>
@@ -933,7 +933,7 @@
 		</setters>
 	</element>
 	<element name="Calm Emotions" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CALM_EMOTIONS">
-		<supports>Bard, Cleric</supports>
+		<supports>Bard, Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to suppress strong emotions in a group of people. Each humanoid in a 20-foot-radius sphere centered on a point you choose within range must make a Charisma saving throw; a creature can choose to fail this saving throw if it wishes. If a creature fails its saving throw, choose one of the following two effects.</p>
 			<p class="indent">You can suppress any effect causing a target to be charmed or frightened. When this spell ends, any suppressed effect resumes, provided that its duration has not expired in the meantime.</p>
@@ -955,7 +955,7 @@
 		</setters>
 	</element>
 	<element name="Chain Lightning" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CHAIN_LIGHTNING">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a bolt of lightning that arcs toward a target of your choice that you can see within range. Three bolts then leap from that target to as many as three other targets, each of which must be within 30 feet of the first target. A target can be a creature or an object and can be targeted by only one of the bolts.</p>
 			<p class="indent">A target must make a Dexterity saving throw. The target takes 10d8 lightning damage on a failed save, or half as much damage on a successful one.</p>
@@ -977,7 +977,7 @@
 		</setters>
 	</element>
 	<element name="Charm Person" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CHARM_PERSON">
-		<supports>Bard, Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to charm a humanoid you can see within range. It must make a Wisdom saving throw, and does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it. The charmed creature regards you as a friendly acquaintance. When the spell ends, the creature knows it was charmed by you.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st. The creatures must be within 30 feet of each other when you target them.</p>
@@ -998,7 +998,7 @@
 		</setters>
 	</element>
 	<element name="Chill Touch" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CHILL_TOUCH">
-		<supports>Sorcerer, Warlock, Wizard</supports>
+		<supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
 		<description>
 			<p>You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can’t regain hit points until the start of your next turn. Until then, the hand clings to the target. If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn. This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -1018,7 +1018,7 @@
 		</setters>
 	</element>
 	<element name="Chromatic Orb" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CHROMATIC_ORB">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Attack</supports>
 		<description>
 			<p>You hurl a 4-inch-diameter sphere of energy at a creature that you can see within range. You choose acid, cold, fire, lightning, poison, or thunder for the type of orb you create, and then make a ranged spell attack against the target. If the attack hits, the creature takes 3d8 damage of the type you choose.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.</p>
@@ -1039,7 +1039,7 @@
 		</setters>
 	</element>
 	<element name="Circle of Death" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CIRCLE_OF_DEATH">
-		<supports>Sorcerer, Warlock, Wizard</supports>
+		<supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A sphere of negative energy ripples out in a 60-foot-radius sphere from a point within range. Each creature in that area must make a Constitution saving throw. A target takes 8d6 necrotic damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 7th level or higher, the damage increases by 2d6 for each slot level above 6th.</p>
@@ -1141,7 +1141,7 @@
 		</setters>
 	</element>
 	<element name="Cloudkill" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CLOUDKILL">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a 20-foot-radius sphere of poisonous, yellow-green fog centered on a point you choose within range. The fog spreads around corners. It lasts for the duration or until strong wind disperses the fog, ending the spell. Its area is heavily obscured. When a creature enters the spell’s area for the first time on a turn or starts its turn there, that creature must make a Constitution saving throw. The creature takes 5d8 poison damage on a failed save, or half as much damage on a successful one. Creatures are affected even if they hold their breath or don’t need to breathe. The fog moves 10 feet away from you at the start of each of your turns, rolling along the surface of the ground. The vapors, being heavier than air, sink to the lowest level of the land, even pouring down openings.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, the damage increases by 1d8 for each slot level above 5th.</p>
@@ -1184,7 +1184,7 @@
 		</setters>
 	</element>
 	<element name="Command" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_COMMAND">
-		<supports>Cleric, Paladin</supports>
+		<supports>Cleric, Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>You speak a one-word command to a creature you can see within range. The target must succeed on a Wisdom saving throw or follow the command on its next turn. The spell has no effect if the target is undead, if it doesn’t understand your language, or if your command is directly harmful to it.  Some typical commands and their effects follow. You might issue a command other than one described here. If you do so, the DM determines how the target behaves. If the target can’t follow your command, the spell ends.</p>  
 			<p class="indent"><b><i>Approach.</i></b> The target moves toward you by the shortest and most direct route, ending its turn if it moves within 5 feet of you.</p>
@@ -1258,7 +1258,7 @@
 		</setters>
 	</element>
 	<element name="Compelled Duel" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_COMPELLED_DUEL">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to compel a creature into a duel. One creature that you can see within range must make a Wisdom saving throw. On a failed save, the creature is drawn to you, compelled by your divine demand. For the duration, it has disadvantage on attack rolls against creatures other than you, and must make a Wisdom saving throw each time it attempts to move to a space that is more than 30 feet away from you</p>
 		</description>
@@ -1299,7 +1299,7 @@
 		</setters>
 	</element>
 	<element name="Compulsion" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_COMPULSION">
-		<supports>Bard</supports>
+		<supports>Bard, Spell Saving Throw</supports>
 		<description>
 			<p>Creatures of your choice that you can see within range and that can hear you must make a Wisdom saving throw. A target automatically succeeds on this saving throw if it can’t be charmed. On a failed save, a target is affected by this spell. Until the spell ends, you can use a bonus action on each of your turns to designate a direction that is horizontal to you. Each affected target must use as much of its movement as possible to move in that direction on its next turn. It can take its action before it moves. After moving in this way, it can make another Wisdom saving throw to try to end the effect. A target isn’t compelled to move into an obviously deadly hazard, such as a fire pit, but it will provoke opportunity attacks to move in the designated direction.</p>
 		</description>
@@ -1319,7 +1319,7 @@
 		</setters>
 	</element>
 	<element name="Cone of Cold" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONE_OF_COLD">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A blast of cold air erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes 8d8 cold damage on a failed save, or half as much damage on a successful one. A creature killed by this spell becomes a frozen statue until it thaws.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, the damage increases by 1d8 for each slot level above 5th.</p>
@@ -1340,7 +1340,7 @@
 		</setters>
 	</element>
 	<element name="Confusion" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONFUSION">
-		<supports>Bard, Druid, Sorcerer, Wizard</supports>
+		<supports>Bard, Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>This spell assaults and twists creatures’ minds, spawning delusions and provoking uncontrolled actions. Each creature in a 10-foot-radius sphere centered on a point you choose within range must succeed on a Wisdom saving throw when you cast this spell or be affected by it.</p>
 			<p class="indent">An affected target can’t take reactions and must roll a d10 at the start of each of its turns to determine its behavior for that turn.</p>
@@ -1400,7 +1400,7 @@
 		</setters>
 	</element>
 	<element name="Conjure Barrage" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONJURE_BARRAGE">
-		<supports>Ranger</supports>
+		<supports>Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>You throw a nonmagical weapon or fire a piece of nonmagical ammunition into the air to create a cone of identical weapons that shoot forward and then disappear. Each creature in a 60-foot cone must succeed on a Dexterity saving throw. A creature takes 3d8 damage on a failed save, or half as much damage on a successful one. The damage type is the same as that of the weapon or ammunition used as a component.</p>
 		</description>
@@ -1513,7 +1513,7 @@
 		</setters>
 	</element>
 	<element name="Conjure Volley" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONJURE_VOLLEY">
-		<supports>Ranger</supports>
+		<supports>Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>You fire a piece of nonmagical ammunition from a ranged weapon or throw a nonmagical weapon into the air and choose a point within range. Hundreds of duplicates of the ammunition or weapon fall in a volley from above and then disappear. Each creature in a 40-foot-radius. 20-foot-high cylinder centered on that point must make a Dexterity saving throw. A creature takes 8d8 damage on a failed save, or half as much damage on a successful one. The damage type is the same as that of the ammunition or weapon.</p>
 		</description>
@@ -1563,7 +1563,7 @@
 		</setters>
 	</element>
 	<element name="Contact Other Plane" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONTACT_OTHER_PLANE">
-		<supports>Warlock, Wizard</supports>
+		<supports>Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You mentally contact a demigod, the spirit of a long-dead sage, or some other mysterious entity from another plane. Contacting this extraplanar intelligence can strain or even break your mind. When you cast this spell, make a DC 15 Intelligence saving throw. On a failure, you take 6d6 psychic damage and are insane until you finish a long rest. While insane, you can’t take actions, can’t understand what other creatures say, can’t read, and speak only in gibberish. A greater restoration spell cast on you ends this effect.</p>
 			<p class="indent">On a successful save, you can ask the entity up to five questions. You must ask your questions before the spell ends. The DM answers each question with one word, such as “yes,” “no,” “maybe,” “never,” “irrelevant,” or “unclear” (if the entity doesn’t know the answer to the question). If a one-word answer would be misleading, the DM might instead offer a short phrase as an answer.</p>
@@ -1584,7 +1584,7 @@
 		</setters>
 	</element>
 	<element name="Contagion" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONTAGION">
-		<supports>Cleric, Druid</supports>
+		<supports>Cleric, Druid, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>Your touch inflicts disease. Make a melee spell attack against a creature within your reach. On a hit, the target is poisoned.</p>
 			<p class="indent">At the end of each of the poisoned target’s turns, the target must make a Constitution saving throw. If the target succeeds on three of these saves, it is no longer poisoned, and the spell ends. If the target fails three of these saves, the target is no longer poisoned, but choose one of the diseases below. The target is subjected to the chosen disease for the spell’s duration.</p> 
@@ -1654,7 +1654,7 @@
 		</setters>
 	</element>
 	<element name="Control Water" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONTROL_WATER">
-		<supports>Cleric, Druid, Wizard</supports>
+		<supports>Cleric, Druid, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Until the spell ends, you control any freestanding water inside an area you choose that is a cube up to 100 feet on a side. You can choose from any of the following effects when you cast this spell. As an action on your turn, you can repeat the same effect or choose a different one.</p>
 			<p class="indent"><b><i>Flood.</i></b> You cause the water level of all standing water in the area to rise by as much as 20 feet. If the area includes a shore, the flooding water spills over onto dry land. If you choose an area in a large body of water, you instead create a 20-foot tall wave that travels from one side of the area to the other and then crashes down. Any Huge or smaller vehicles in the wave’s path are carried with it to the other side. Any Huge or smaller vehicles struck by the wave have a 25 percent chance of capsizing. The water level remains elevated until the spell ends or you choose a different effect. If this effect produced a wave, the wave repeats on the start of your next turn while the flood effect lasts.</p>
@@ -1728,7 +1728,7 @@
 		</setters>
 	</element>
 	<element name="Cordon of Arrows" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CORDON_OF_ARROWS">
-		<supports>Ranger</supports>
+		<supports>Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>You plant four pieces of nonmagical ammunition - arrows or crossbow bolts - in the ground within range and lay magic upon them to protect an area. Until the spell ends, whenever a creature other than you comes within 30 feet of the ammunition for the first time on a turn or ends its turn there, one piece of ammunition flies up to strike it. The creature must succeed on a Dexterity saving throw or take 1d6 piercing damage. The piece of ammunition is then destroyed. The spell ends when no ammunition remains. When you cast this spell, you can designate any creatures you choose, and the spell ignores them.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the amount of ammunition that can be affected increases by two for each slot level above 2nd
@@ -1854,7 +1854,7 @@
 		</setters>
 	</element>
 	<element name="Crown of Madness" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CROWN_OF_MADNESS">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>One humanoid of your choice that you can see within range must succeed on a Wisdom saving throw or become charmed by you for the duration. While the target is charmed in this way, a twisted crown of jagged iron appears on its head, and a madness glows in its eyes. The charmed target must use its action before moving on each of its turns to make a melee attack against a creature other than itself that you mentally choose. The target can act normally on its turn if you choose no creature or if none are within its reach. On your subsequent turns, you must use your action to maintain control over the target, or the spell ends. Also, the target can make a Wisdom saving throw at the end of each of its turns. On a success, the spell ends.</p>
 		</description>
@@ -2017,7 +2017,7 @@
 		</setters>
 	</element>
 	<element name="Delayed Blast Fireball" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DELAYED_BLAST_FIREBALL">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A beam of yellow light flashes from your pointing finger, then condenses to linger at a chosen point within range as a glowing bead for the duration. When the spell ends, either because your concentration is broken or because you decide to end it, the bead blossoms with a low roar into an explosion of flame that spreads around corners. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes fire damage equal to the total accumulated damage on a failed save, or half as much damage on a successful one. The spell’s base damage is 12d6. If at the end of your turn the bead has not yet detonated, the damage increases by 1d6. If the glowing bead is touched before the interval has expired, the creature touching it must make a Dexterity saving throw. On a failed save, the spell ends immediately, causing the bead to erupt in flame. On a successful save, the creature can throw the bead up to 40 feet. When it strikes a creature or a solid object, the spell ends, and the bead explodes. The fire damages objects in the area and ignites flammable objects that aren’t being worn or carried.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 8th level or higher, the base damage increases by 1d6 for each slot level above 7th.</p>
@@ -2058,7 +2058,7 @@
 		</setters>
 	</element>
 	<element name="Destructive Wave" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DESTRUCTIVE_WAVE">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>You strike the ground, creating a burst of divine energy that ripples outward from you. Each creature you choose within 30 feet of you must succeed on a Constitution saving throw or take 5d6 thunder damage, as well as 5d6 radiant or necrotic damage (your choice), and be knocked prone. A creature that succeeds on its saving throw takes half as much damage and isn’t knocked prone.</p>
 		</description>
@@ -2138,7 +2138,7 @@
 		</setters>
 	</element>
 	<element name="Detect Thoughts" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DETECT_THOUGHTS">
-		<supports>Bard, Sorcerer, Wizard</supports>
+		<supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>For the duration, you can read the thoughts of certain creatures. When you cast the spell and as your action on each turn until the spell ends, you can focus your mind on any one creature that you can see within 30 feet of you. If the creature you choose has an Intelligence of 3 or lower or doesn’t speak any language, the creature is unaffected.</p>
 			<p class="indent">You initially learn the surface thoughts of the creature—what is most on its mind in that moment. As an action, you can either shift your attention to another creature’s thoughts or attempt to probe deeper into the same creature’s mind. If you probe deeper, the target must make a Wisdom saving throw. If it fails, you gain insight into its reasoning (if any), its emotional state, and something that looms large in its mind (such as something it worries over, loves, or hates). If it succeeds, the spell ends. Either way, the target knows that you are probing into its mind, and unless you shift your attention to another creature’s thoughts, the creature can use its action on its turn to make an Intelligence check contested by your Intelligence check; if it succeeds, the spell ends.</p>
@@ -2204,7 +2204,7 @@
 		</setters>
 	</element>
 	<element name="Disintegrate" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DISINTEGRATE">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A thin green ray springs from your pointing finger to a target that you can see within range. The target can be a creature, an object, or a creation of magical force, such as the wall created by wall of force.</p>
 			<p class="indent">A creature targeted by this spell must make a Dexterity saving throw. On a failed save, the target takes 10d6 + 40 force damage. The target is disintegrated if this damage leaves it with 0 hit points</p>
@@ -2228,7 +2228,7 @@
 		</setters>
 	</element>
 	<element name="Dispel Evil and Good" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DISPEL_EVIL_AND_GOOD">
-		<supports>Cleric, Paladin</supports>
+		<supports>Cleric, Paladin, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>Shimmering energy surrounds and protects you from fey, undead, and creatures originating from beyond the Material Plane. For the duration, celestials, elementals, fey, fiends, and undead have disadvantage on attack rolls against you. You can end the spell early by using either of the following special functions. Break  Enchantment. As your action, you touch a creature you can reach that is charmed, frightened, or possessed by a celestial, an elemental, a fey, a fiend, or an undead. The creature you touch is no longer charmed, frightened, or possessed by such creatures. Dismissal. As your action, make a melee spell attack against a celestial, an elemental, a fey, a fiend, or an undead you can reach. On a hit, you attempt to drive the creature back to its home plane. The creature must succeed on a Charisma saving throw or be sent back to its home plane (if it isn’t there already). If they aren’t on their home plane, undead are sent to the Shadowfell, and fey are sent to the Feywild.</p>
 		</description>
@@ -2269,7 +2269,7 @@
 		</setters>
 	</element>
 	<element name="Dissonant Whispers" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DISSONANT_WHISPERS">
-		<supports>Bard</supports>
+		<supports>Bard, Spell Saving Throw</supports>
 		<description>
 			<p>You whisper a discordant melody that only one creature of your choice within range can hear, wracking it with terrible pain. The target must make a Wisdom saving throw. On a failed save, it takes 3d6 psychic damage and must immediately use its reaction , if available, to move as far as its speed allows away from you. The creature doesn’t move into obviously dangerous ground, such as a fire or a pit. On a successful save, the target takes half as much damage and doesn’t have to move away. A deafened creature automatically succeeds on the save.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -2330,7 +2330,7 @@
 		</setters>
 	</element>
 	<element name="Divine Word" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DIVINE_WORD">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>You utter a divine word, imbued with the power that shaped the world at the dawn of creation. Choose any number of creatures you can see within range. Each creature that can hear you must make a Charisma saving throw. On a failed save, a creature suffers an effect based on its current hit points:</p>
 		<ul>
@@ -2357,7 +2357,7 @@
 		</setters>
 	</element>
 	<element name="Dominate Beast" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DOMINATE_BEAST">
-		<supports>Druid, Sorcerer</supports>
+		<supports>Druid, Sorcerer, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to beguile a beast that you can see within range. It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw. While the beast is charmed, you have a telepathic link with it as long as the two of you are on the same plane of existence. You can use this telepathic link to issue commands to the creature while you are conscious (no action required), which it does its best to obey. You can specify a simple and general course of action, such as “Attack that creature,” “Run over there,” or “Fetch that object.” If the creature completes the order and doesn’t receive further direction from you, it defends and preserves itself to the best of its ability. You can use your action to take total and precise control of the target. Until the end of your next turn, the creature takes only the actions you choose, and doesn’t do anything that you don’t allow it to do. During this time, you can also cause the creature to use a reaction, but this requires you to use your own reaction as well. Each time the target takes damage, it makes a new Wisdom saving throw against the spell. If the saving throw succeeds, the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell with a 5th-level spell slot, the duration is concentration, up to 10 minutes. When you use a 6th-level spell slot, the duration is concentration, up to  1 hour. When you use a spell slot of 7th level or higher, the duration is concentration, up to 8 hours.</p>
@@ -2378,7 +2378,7 @@
 		</setters>
 	</element>
 	<element name="Dominate Monster" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DOMINATE_MONSTER">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to beguile a creature that you can see within range. It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw. While the creature is charmed, you have a telepathic link with it as long as the two of you are on the same plane of existence. You can use this telepathic link to issue commands to the creature while you are conscious (no action required), which it does its best to obey. You can specify a simple and general course of action, such as “Attack that creature,” “Run over there,” or “Fetch that object.” If the creature completes the order and doesn’t receive further direction from you, it defends and preserves itself to the best of its ability. You can use your action to take total and precise control of the target. Until the end of your next turn, the creature takes only the actions you choose, and doesn’t do anything that you don’t allow it to do. During this time, you can also cause the creature to use a reaction, but this requires you to use your own reaction as well. Each time the target takes damage, it makes a new Wisdom saving throw against the spell. If the saving throw succeeds, the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell with a 9th-level spell slot, the duration is concentration, up to 8 hours.</p>
@@ -2399,7 +2399,7 @@
 		</setters>
 	</element>
 	<element name="Dominate Person" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DOMINATE_PERSON">
-		<supports>Bard, Sorcerer, Wizard</supports>
+		<supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to beguile a humanoid that you can see within range. It must succeed on a Wisdom saving throw or be charmed by you for the duration. If you or creatures that are friendly to you are fighting it, it has advantage on the saving throw. While the target is charmed, you have a telepathic link with it as long as the two of you are on the same plane of existence. You can use this telepathic link to issue commands to the creature while you are conscious (no action required), which it does its best to obey. You can specify a simple and general course of action, such as “Attack that creature,” “Run over there,” or “Fetch that object.” If the creature completes the order and doesn’t receive further direction from you, it defends and preserves itself to the best of its ability. You can use your action to take total and precise control of the target. Until the end of your next turn, the creature takes only the actions you choose, and doesn’t do anything that you don’t allow it to do. During this time you can also cause the creature to use a reaction, but this requires you to use your own reaction as well. Each time the target takes damage, it makes a new Wisdom saving throw against the spell. If the saving throw succeeds, the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a 6th-level spell slot, the duration is concentration, up to 10 minutes. When you use a 7th-level spell slot, the duration is concentration, up to 1 hour. When you use a spell slot of 8th level or higher, the duration is concentration, up to 8 hours.</p>
@@ -2443,7 +2443,7 @@
 		</setters>
 	</element>
 	<element name="Dream" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_DREAM">
-		<supports>Bard, Warlock, Wizard</supports>
+		<supports>Bard, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>This spell shapes a creature’s dreams. Choose a creature known to you as the target of this spell. The target must be on the same plane of existence as you. Creatures that don’t sleep, such as elves, can’t be contacted by this spell. You, or a willing creature you touch, enters a trance state, acting as a messenger. While in the trance, the messenger is aware of his or her surroundings, but can’t take actions or move.</p>
 			<p class="indent">If the target is asleep, the messenger appears in the target’s dreams and can converse with the target as long as it remains asleep, through the duration of the spell. The messenger can also shape the environment of the dream, creating landscapes, objects, and other images. The messenger can emerge from the trance at any time, ending the effect of the spell early. The target recalls the dream perfectly upon waking. If the target is awake when you cast the spell, the messenger knows it, and can either end the trance (and the spell) or wait for the target to fall asleep, at which point the messenger appears in the target’s dreams.</p> 
@@ -2492,7 +2492,7 @@
 		</setters>
 	</element>
 	<element name="Earthquake" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_EARTHQUAKE">
-		<supports>Cleric, Druid, Sorcerer</supports>
+		<supports>Cleric, Druid, Sorcerer, Spell Saving Throw</supports>
 		<description>
 			<p>You create a seismic disturbance at a point on the ground that you can see within range. For the duration, an intense tremor rips through the ground in a 100-foot- radius circle centered on that point and shakes creatures and structures in contact with the ground in that area.</p>
 			<p class="indent">The ground in the area becomes difficult terrain. Each creature on the ground that is concentrating must make a Constitution saving throw. On a failed save, the creature’s concentration is broken.</p>
@@ -2518,7 +2518,7 @@
 		</setters>
 	</element>
 	<element name="Eldritch Blast" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ELDRITCH_BLAST">
-		<supports>Warlock</supports>
+		<supports>Warlock, Spell Attack</supports>
 		<description>
 			<p>A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage.</p>
 		<p class="indent">The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. you can direct the beams at the same target or at different ones. Make a separate attack roll for each beam.</p>
@@ -2587,7 +2587,7 @@
 		</setters>
 	</element>
 	<element name="Enlarge/Reduce" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ENLARGE_REDUCE">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>You cause a creature or an object you can see within range to grow larger or smaller for the duration. Choose either a creature or an object that is neither worn nor carried. If the target is unwilling, it can make a Constitution saving throw. On a success, the spell has no effect.</p>
 			<p class="indent">If the target is a creature, everything it is wearing and carrying changes size with it. Any item dropped by an affected creature returns to normal size at once.</p>
@@ -2610,7 +2610,7 @@
 		</setters>
 	</element>
 	<element name="Ensnaring Strike" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ENSNARING_STRIKE">
-		<supports>Ranger</supports>
+		<supports>Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you hit a creature with a weapon attack before this spell ends, a writhing mass of thorny vines appears at the point of impact, and the target must succeed on a Strength saving throw or be restrained by the magical vines until the spell ends. A Large or larger creature has advantage on this saving throw. If the target succeeds on the save, the vines shrivel away. While restrained by this spell, the target takes 1d6 piercing damage at the start of each of its turns. A creature restrained by the vines or one that can touch the creature can use its action to make a Strength check against your spell save DC. On a success, the target is freed.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -2631,7 +2631,7 @@
 		</setters>
 	</element>
 	<element name="Entangle" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ENTANGLE">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>Grasping weeds and vines sprout from the ground in a 20-foot square starting from a point within range. For the duration, these plants turn the ground in the area into difficult terrain. A creature in the area when you cast the spell must succeed on a Strength saving throw or be restrained by the entangling plants until the spell ends. A creature restrained by the plants can use its action to make a Strength check against your spell save DC. On a success, it frees itself. When the spell ends, the conjured plants wilt away.</p>
 		</description>
@@ -2651,7 +2651,7 @@
 		</setters>
 	</element>
 	<element name="Enthrall" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ENTHRALL">
-		<supports>Bard, Warlock</supports>
+		<supports>Bard, Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>You weave a distracting string of words, causing creatures of your choice that you can see within range and that can hear you to make a Wisdom saving throw. Any creature that can’t be charmed succeeds on this saving throw automatically, and if you or your companions are fighting a creature, it has advantage on the save. On a failed save, the target has disadvantage on Wisdom (Perception) checks made to perceive any creature other than you until the spell ends or until the target can no longer hear you. The spell ends if you are incapacitated or can no longer speak.</p>
 		</description>
@@ -2692,7 +2692,7 @@
 		</setters>
 	</element>
 	<element name="Evard’s Black Tentacles" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_EVARDS_BLACK_TENTACLES">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Squirming, ebony tentacles fill a 20-foot square on ground that you can see within range. For the duration, these tentacles turn the ground in the area into difficult terrain. When a creature enters the affected area for the first time on a turn or starts its turn there, the creature must succeed on a Dexterity saving throw or take 3d6 bludgeoning damage and be restrained by the tentacles until the spell ends. A creature that starts its turn in the area and is already restrained by the tentacles takes 3d6 bludgeoning damage. A creature restrained by the tentacles can use its action to make a Strength or Dexterity check (its choice) against your spell save DC. On a success, it frees itself.</p>
 		</description>
@@ -2732,7 +2732,7 @@
 		</setters>
 	</element>
 	<element name="Eyebite" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_EYEBITE">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>For the spell’s duration, your eyes become an inky void imbued with dread power. One creature of your choice within 60 feet of you that you can see must succeed on a Wisdom saving throw or be affected by one of the following effects of your choice for the duration. On each of your turns until the spell ends, you can use your action to target another creature but can’t target a creature again if it has succeeded on a saving throw against this casting of eyebite.</p>
 			<p class="indent"><b><i>Asleep.</i></b> The target galls unconscious. It wakes up if it takes any damage or if another creature uses its action to shake the sleeper awake.</p>
@@ -2777,7 +2777,7 @@
 		</setters>
 	</element>
 	<element name="Faerie Fire" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FAERIE_FIRE">
-		<supports>Bard, Druid, Artificer</supports>
+		<supports>Bard, Druid, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>Each object in a 20-foot cube within range is outlined in blue, green, or violet light (your choice). Any creature in the area when the spell is cast is also outlined in light if it fails a Dexterity saving throw. For the duration, objects and affected creatures shed dim light in a 10-foot radius.</p>
 			<p class="indent">Any attack roll against an affected creature or object has advantage if the attacker can see it, and the affected creature or object can’t benefit from being invisible.</p>
@@ -2819,7 +2819,7 @@
 		</setters>
 	</element>
 	<element name="Fear" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FEAR">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You project a phantasmal image of a creature’s worst fears. Each creature in a 30-foot cone must succeed on a Wisdom saving throw or drop whatever it is holding and become frightened for the duration.</p>
 			<p class="indent">While frightened by this spell, a creature must take the Dash action and move away from you by the safest available route on each of its turns, unless there is nowhere to move. If the creature ends its turn in a location where it doesn’t have line of sight to you, the creature can make a Wisdom saving throw. On a successful save, the spell ends for that creature.</p>
@@ -2860,7 +2860,7 @@
 		</setters>
 	</element>
 	<element name="Feeblemind" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FEEBLEMIND">
-		<supports>Bard, Druid, Warlock, Wizard</supports>
+		<supports>Bard, Druid, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You blast the mind of a creature that you can see within range, attempting to shatter its intellect and personality. The target takes 4d6 psychic damage and must make an Intelligence saving throw.</p>
 			<p class="indent">On a failed save, the creature’s Intelligence and Charisma scores become 1. The creature can’t cast spells, activate magic items, understand language, or communicate in any intelligible way. The creature can, however, identify its friends, follow them, and even protect them.</p>
@@ -2995,7 +2995,7 @@
 		</setters>
 	</element>
 	<element name="Finger of Death" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FINGER_OF_DEATH">
-		<supports>Sorcerer, Warlock, Wizard</supports>
+		<supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You send negative energy coursing through a creature that you can see within range, causing it searing pain. The target must make a Constitution saving throw. It takes 7d8 + 30 necrotic damage on a failed save, or half as much damage on a successful one. A humanoid killed by this spell rises at the start of your next turn as a zombie that is permanently under your command, following your verbal orders to the best of its ability.</p>
 		</description>
@@ -3015,7 +3015,7 @@
 		</setters>
 	</element>
 	<element name="Fire Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FIRE_BOLT">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Attack</supports>
 		<description>
 			<p>You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn’t being worn or carried.</p>
 			<p class="indent">This spell’s damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</p>
@@ -3056,7 +3056,7 @@
 		</setters>
 	</element>
 	<element name="Fire Storm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FIRE_STORM">
-		<supports>Cleric, Druid, Sorcerer</supports>
+		<supports>Cleric, Druid, Sorcerer, Spell Saving Throw</supports>
 		<description>
 			<p>A storm made up of sheets of roaring flame appears in a location you choose within range. The area of the storm consists of up to ten 10-foot cubes, which you can arrange as you wish. Each cube must have at least one face adjacent to the face of another cube. Each creature in the area must make  Dexterity saving throw. It takes 7d10 fire damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent">The fire damages objects in the area and ignites flammable objects that aren’t being worn or carried. If you choose, plant life in the area is unaffected by this spell.</p>
@@ -3077,7 +3077,7 @@
 		</setters>
 	</element>
 	<element name="Fireball" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FIREBALL">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes 8d6 fire damage on a failed save, or half as much damage on a successful one.</p>
 			<p>The fire spreads around corners. It ignites flammable objects in the area that aren’t being worn or carried.</p>
@@ -3099,7 +3099,7 @@
 		</setters>
 	</element>
 	<element name="Flame Blade" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FLAME_BLADE">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Attack</supports>
 		<description>
 			<p>You evoke a fiery blade in your free hand. The blade is similar in size and shape to a scimitar, and it lasts for the duration. If you let go of the blade, it disappears, but you can evoke the blade again as a bonus action. You can use your action to make a melee spell attack with the fiery blade. On a hit, the target takes 3d6 fire damage. The flaming blade sheds bright light in a 10-foot radius and dim light for an additional 10 feet.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for every two slot levels above 2nd.</p>
@@ -3120,7 +3120,7 @@
 		</setters>
 	</element>
 	<element name="Flame Strike" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FLAME_STRIKE">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>A vertical column of divine fire roars down from the heavens in a location you specify. Each creature in a 10-foot radius, 40-foot-high cylinder centered on a point within range must make a Dexterity saving throw. A creature takes 4d6 fire damage and 4d6 radiant damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, the fire damage or the radiant damage (your choice) increases by 1d6 for each slot level above 5th.</p>
@@ -3141,7 +3141,7 @@
 		</setters>
 	</element>
 	<element name="Flaming Sphere" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FLAMING_SPHERE">
-		<supports>Druid, Wizard</supports>
+		<supports>Druid, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A 5-foot-diameter sphere of fire appears in an unoccupied space of your choice within range and lasts for the duration. Any creature that ends its turn within 5 feet of the sphere must make a Dexterity saving throw. The creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one. As a bonus action, you can move the sphere up to 30 feet. If you ram the sphere into a creature, that creature must make the saving throw against the sphere’s damage, and the sphere stops moving this turn. When you move the sphere, you can direct it over barriers up to 5 feet tall and jump it across pits up to 10 feet wide. The sphere ignites flammable objects not being worn or carried, and it sheds bright light in a 20-foot radius and dim light for an additional 20 feet.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</p>
@@ -3162,7 +3162,7 @@
 		</setters>
 	</element>
 	<element name="Flesh to Stone" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FLESH_TO_STONE">
-		<supports>Warlock, Wizard</supports>
+		<supports>Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to turn one creature that you can see within range into stone. If the targets body is made of flesh, the creature must make a Constitution saving throw. On a failed save, it is restrained as its flesh begins to harden. On a successful save, the creature isn’t affected. A creature restrained by this spell must make another Constitution saving throw at the end of each of its turns. If it successfully saves against this spell three times, the spell ends. If it fails saves three times, it is turned to stone and subjected to the petrified condition for the duration. The successes and failures don’t need to be consecutive</p>
 		</description>
@@ -3244,7 +3244,7 @@
 		</setters>
 	</element>
 	<element name="Forcecage" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FORCECAGE">
-		<supports>Bard, Warlock, Wizard</supports>
+		<supports>Bard, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>An immobile, invisible, cube-shaped prison composed of magical force springs into existence around an area you choose within range. The prison can be a cage or a solid box as you choose. A prison in the shape of a cage can be up to 20 feet on a side and is made from 1/2-inch diameter bars spaced 1/2 inch apart. A prison in the shape of a box can be up to 10 feet on a side, creating a solid barrier that prevents any matter from passing through it and blocking any spells cast into or out of the area. When you cast the spell, any creature that is completely inside the cage’s area is trapped. Creatures only partially within the area, or those too large to fit inside the area, are pushed away from the center of the area until they are completely outside the area. A creature inside the cage can’t leave it by nonmagical means. If the creature tries to use teleportation or interplanar travel to leave the cage, it must first make a Charisma saving throw. On a success, the creature can use that magic to exit the cage. On a failure, the creature can’t exit the cage and wastes the use of the spell or effect. The cage also extends into the Ethereal Plane, blocking ethereal travel. This spell can’t be dispelled by dispel magic.</p>
 		</description>
@@ -3364,7 +3364,7 @@
 		</setters>
 	</element>
 	<element name="Geas" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GEAS">
-		<supports>Bard, Cleric, Druid, Paladin, Wizard</supports>
+		<supports>Bard, Cleric, Druid, Paladin, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You place a magical command on a creature that you can see within range, forcing it to carry out some service or refrain from some action or course of activity as you decide. If the creature can understand you, it must succeed on a Wisdom saving throw or become charmed by you for the duration. While the creature is charmed by you, it takes 5d10 psychic damage each time it acts in a manner directly counter to your instructions, but no more than once each day. A creature that can’t understand you is unaffected by the spell. You can issue any command you choose, short of an activity that would result in certain death. Should you issue a suicidal command, the spell ends. You can end the spell early by using an action to dismiss it. A remove curse, greater restoration, or wish spell also ends it.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 7th or 8th level, the duration is 1 year. When you cast this spell using a spell slot of 9th level the spell lasts until it is ended by one of the spells mentioned above.</p>
@@ -3466,7 +3466,7 @@
 		</setters>
 	</element>
 	<element name="Glyph of Warding" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GLYPH_OF_WARDING">
-		<supports>Bard, Cleric, Wizard, Artificer</supports>
+		<supports>Bard, Cleric, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>When you cast this spell, you inscribe a glyph that later unleashes a magical effect. You inscribe it either on a surface (such as a table or a section of floor or wall) or within an object that can be closed (such as a book, a scroll, or a treasure chest) to conceal the glyph. The glyph can cover an area no larger than 10 feet in diameter. If the surface or object is moved more than 10 feet from where you cast this spell, the glyph is broken, and the spell ends without being triggered.</p>
 			<p class="indent">The glyph is nearly Invisible and requires a successful Intelligence (Investigation) check against your spell save DC to be found.</p>
@@ -3513,7 +3513,7 @@
 		</setters>
 	</element>
 	<element name="Grasping Vine" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GRASPING_VINE">
-		<supports>Druid, Ranger</supports>
+		<supports>Druid, Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>You conjure a vine that sprouts from the ground in an unoccupied space of your choice that you can see within range. When you cast this spell, you can direct the vine to lash out at a creature within 30 feet of it that you can see. That creature must succeed on a Dexterity saving throw or be pulled 20 feet directly toward the vine. Until the spell ends, you can direct the vine to lash out at the same creature or another one as a bonus action on each of your turns.</p>
 		</description>
@@ -3533,7 +3533,7 @@
 		</setters>
 	</element>
 	<element name="Grease" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GREASE">
-		<supports>Wizard, Artificer</supports>
+		<supports>Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>Slick grease covers the ground in a 10-foot square centered on a point within range and turns it into difficult terrain for the duration. When the grease appears, each creature standing in its area must succeed on a Dexterity saving throw or fall prone. A creature that enters the area or ends its turn there must also succeed on a Dexterity saving throw or fall prone.</p>
 		</description>
@@ -3599,7 +3599,7 @@
 		</setters>
 	</element>
 	<element name="Guardian of Faith" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GUARDIAN_OF_FAITH">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>A Large spectral guardian appears and hovers for the duration in an unoccupied space of your choice that you can see within range. The guardian occupies that space and is indistinct except for a gleaming sword and shield emblazoned with the symbol of your deity. Any creature hostile to you that moves to a space within 10 feet of the guardian for the first time on a turn must succeed on a Dexterity saving throw. The creature takes 20 radiant damage on a failed save, or half as much damage on a successful one. The guardian vanishes when it has dealt a total of 60 damage.</p>
 		</description>
@@ -3674,7 +3674,7 @@
 		</setters>
 	</element>
 	<element name="Guiding Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GUIDING_BOLT">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Attack</supports>
 		<description>
 			<p>A flash of light streaks toward a creature of your choice within range. Make a ranged spell attack against the target. On a hit, the target takes 4d6 radiant damage, and the next attack roll made against this target before the end of your next turn has advantage, thanks to the mystical dim light glittering on the target until then.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -3695,7 +3695,7 @@
 		</setters>
 	</element>
 	<element name="Gust of Wind" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_GUST_OF_WIND">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A line of strong wind 60 feet long and 10 feet wide blasts from you in a direction you choose for the spell’s duration. Each creature that starts its turn in the line must succeed on a Strength saving throw or be pushed 15 feet away from you in a direction following the line.</p>
 			<p class="indent">Any creature in the line must spend 2 feet of movement for every 1 foot it moves when moving closer to you.</p>
@@ -3718,7 +3718,7 @@
 		</setters>
 	</element>
 	<element name="Hail of Thorns" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HAIL_OF_THORNS">
-		<supports>Ranger</supports>
+		<supports>Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you hit a creature with a ranged weapon attack before the spell ends, this spell creates a rain of thorns that sprouts from your ranged weapon or ammunition. In addition to the normal effect of the attack, the target of the attack and each creature within 5 feet of it must make a Dexterity saving throw. A creature takes 1d10 piercing damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> If you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d10 for each slot level above 1st (to a maximum of 6d10).</p>
@@ -3779,7 +3779,7 @@
 		</setters>
 	</element>
 	<element name="Harm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HARM">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>You unleash a virulent disease on a creature that you can see within range. The target must make a Constitution saving throw. On a failed save, it takes 14d6 necrotic damage, or half as much damage on a successful save. The damage can’t reduce the target’s hit points below 1. If the target fails the saving throw, its hit point maximum is reduced for 1 hour by an amount equal to the necrotic damage it took. Any effect that removes a disease allows a creature’s hit point maximum to return to normal before that time passes.</p>
 		</description>
@@ -3861,7 +3861,7 @@
 		</setters>
 	</element>
 	<element name="Heat Metal" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HEAT_METAL">
-		<supports>Bard, Druid, Artificer</supports>
+		<supports>Bard, Druid, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>Choose a manufactured metal object, such as a metal weapon or a suit of heavy or medium metal armor, that you can see within range. You cause the object to glow red-hot. Any creature in physical contact with the object takes 2d8 fire damage when you cast the spell. Until the spell ends, you can use a bonus action on each of your subsequent turns to cause this damage again. If a creature is holding or wearing the object and takes the damage from it, the creature must succeed on a Constitution saving throw or drop the object if it can. If it doesn’t drop the object, it has disadvantage on attack rolls and ability checks until the start of your next turn.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot above 2nd.</p>
@@ -3882,7 +3882,7 @@
 		</setters>
 	</element>
 	<element name="Hellish Rebuke" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HELLISH_REBUKE">
-		<supports>Warlock</supports>
+		<supports>Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>Reaction: you are being damaged by a creature within 60 feet of you that you can see You point your finger, and the creature that damaged you is momentarily surrounded by hellish flames. The creature must make a Dexterity saving throw. It takes 2d10 fire damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d10 for each slot level above 1st.</p>
@@ -3965,7 +3965,7 @@
 		</setters>
 	</element>
 	<element name="Hold Monster" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HOLD_MONSTER">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose a creature that you can see within range. The target must succeed on a Wisdom saving throw or be paralyzed for the duration. This spell has no effect on undead. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, you can target on additional creature for each slot level above 5th. The creatures must be within 30 feet of each other when you target them.</p>
@@ -3986,7 +3986,7 @@
 		</setters>
 	</element>
 	<element name="Hold Person" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HOLD_PERSON">
-		<supports>Bard, Cleric, Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Cleric, Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose a humanoid that you can see within range. The target must succeed on a Wisdom saving throw or be paralyzed for the duration. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, you can target on additional humanoid for each slot level above 2nd. The humanoids must be within 30 feet of each other when you target them.</p>
@@ -4007,7 +4007,7 @@
 		</setters>
 	</element>
 	<element name="Holy Aura" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HOLY_AURA">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>Divine light washes out from you and coalesces in a soft radiance in a 30-foot radius around you. Creatures of your choice in that radius when you cast this spell shed dim light in a 5-foot radius and have advantage on all saving throws, and other creatures have disadvantage on attack rolls against them until the spell ends. In addition, when a fiend or an undead hits an affected creature with a melee attack, the aura flashes with brilliant light. The attacker must succeed on a Constitution saving throw or be blinded until the spell ends.</p>
 		</description>
@@ -4027,7 +4027,7 @@
 		</setters>
 	</element>
 	<element name="Hunger of Hadar" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HUNGER_OF_HADAR">
-		<supports>Warlock</supports>
+		<supports>Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>You open a gateway to the dark between the stars, a region infested with unknown horrors. A 20-foot-radius sphere of blackness and bitter cold appears, centered on a point with range and lasting for the duration. This void is filled with a cacophony of soft whispers and slurping noises that can be heard up to 30 feet away. No light, magical or otherwise, can illuminate the area, and creatures fully within the area are blinded.</p>
 			<p class="indent">The void creates a warp in the fabric of space, and the area is difficult terrain. Any creature that starts its turn in the area takes 2d6 cold damage. Any creature that ends its turn in the area must succeed on a Dexterity saving throw or take 2d6 acid damage as milky, otherworldly tentacles rub against it.</p>
@@ -4069,7 +4069,7 @@
 		</setters>
 	</element>
 	<element name="Hypnotic Pattern" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_HYPNOTIC_PATTERN">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a twisting pattern of colors that weaves through the air inside a 30-foot cube within range. The pattern appears for a moment and vanishes. Each creature in the area who sees the pattern must make a Wisdom saving throw. On a failed save, the creature becomes charmed for the duration. While charmed by this spell, the creature is incapacitated and has a speed of 0. The spell ends for an affected creature if it takes any damage or if someone else uses an action to shake the creature out of its stupor.</p>
 		</description>
@@ -4089,7 +4089,7 @@
 		</setters>
 	</element>
 	<element name="Ice Storm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ICE_STORM">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A hail of rock-hard ice pounds to the ground in a 20-foot-radius, 40-foot-high cylinder centered on a point within range. Each creature in the cylinder must make a Dexterity saving throw. A creature takes 2d8 bludgeoning damage and 4d6 cold damage on a failed save, or half as much damage on a successful one. Hailstones turn the storm’s area of effect into difficult terrain until the end of your next turn.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 5th level or higher, the bludgeoning damage increases by 1d8 for each slot level above 4th.</p>
@@ -4150,7 +4150,7 @@
 		</setters>
 	</element>
 	<element name="Imprisonment" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_IMPRISONMENT">
-		<supports>Warlock, Wizard</supports>
+		<supports>Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a magical restraint to hold a creature that you can see within range. The target must succeed on a Wisdom saving throw or be bound by the spell</p>
 		</description>
@@ -4170,7 +4170,7 @@
 		</setters>
 	</element>
 	<element name="Incendiary Cloud" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_INCENDIARY_CLOUD">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A swirling cloud of smoke shot through with white-hot embers appears in a 20-foot-radius sphere centered on a point within range. The cloud spreads around corners and is heavily obscured. It lasts for the duration or until a wind of moderate or greater speed (at least 10 miles per hour) disperses it. When the cloud appears, each creature in it must make a Dexterity saving throw. A creature takes 10d8 fire damage on a failed save, or half as much damage on a successful one. A creature must also make this saving throw when it enters the spell’s area for the first time on a turn or ends its turn there. The cloud moves 10 feet directly away from you in a direction that you choose at the start of each of your turns.</p>
 		</description>
@@ -4190,7 +4190,7 @@
 		</setters>
 	</element>
 	<element name="Inflict Wounds" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_INFLICT_WOUNDS">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Attack</supports>
 		<description>
 			<p>Make a melee spell attack against a creature you can reach. On a hit, the target takes 3d10 necrotic damage.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d10 for each slot level above 1st.</p>
@@ -4211,7 +4211,7 @@
 		</setters>
 	</element>
 	<element name="Insect Plague" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_INSECT_PLAGUE">
-		<supports>Cleric, Druid, Sorcerer</supports>
+		<supports>Cleric, Druid, Sorcerer, Spell Saving Throw</supports>
 		<description>
 			<p>Swarming, biting locusts fill a 20-foot-radius sphere centered on a point you choose within range. The sphere spreads around corners. The sphere remains for the duration, and its area is lightly obscured. The sphere’s area is difficult terrain. When the area appears, each creature in it must make a Constitution saving throw. A creature takes 4d10 piercing damage on a failed save, or half as much damage on a successful one. A creature must also make this saving throw when it enters the spell’s area for the first time on a turn or ends its turn there.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 6th level or higher, the damage increases by 1d10 for each slot level above 5th.</p>
@@ -4381,7 +4381,7 @@
 		</setters>
 	</element>
 	<element name="Levitate" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_LEVITATE">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>One creature or loose object of your choice that you can see within range rises vertically, up to 20 feet, and remains suspended there for the duration. The spell can levitate a target that weighs up to 500 pounds. An unwilling creature that succeeds on a Constitution saving throw is unaffected. The target can move only by pushing or pulling against a fixed object or surface within reach (such as a wall or a ceiling), which allows it to move as if it were climbing. You can change the target’s altitude by up to 20 feet in either direction on your turn. If you are the target, you can move up or down as part of your move. Otherwise, you can use your action to move the target, which must remain within the spell’s range. When the spell ends, the target floats gently to the ground if it is still aloft.</p>
 		</description>
@@ -4401,7 +4401,7 @@
 		</setters>
 	</element>
 	<element name="Light" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_LIGHT">
-		<supports>Bard, Cleric, Sorcerer, Wizard, Artificer</supports>
+		<supports>Bard, Cleric, Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>You touch one object that is no larger than 10 feet in any dimension. Until the spell ends, the object sheds bright light in a 20-foot radius and dim light for an additional 20 feet. The light can be colored as you like. Completely covering the object with something opaque blocks the light. The spell ends if you cast it again or dismiss it as an action.</p>
 			<p class="indent">If you target an object held or worn by a hostile creature, that creature must succeed on a Dexterity saving throw to avoid the spell.</p>
@@ -4422,7 +4422,7 @@
 		</setters>
 	</element>
 	<element name="Lightning Arrow" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_LIGHTNING_ARROW">
-		<supports>Ranger</supports>
+		<supports>Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you make a ranged weapon attack during the spell’s duration, the weapon’s ammunition, or the weapon itself if it’s a thrown weapon, transforms into a bolt of lightning. Make the attack roll as normal, The target takes 4d8 lightning damage on a hit, or half as much damage on a miss, instead of the weapon’s normal damage. Whether you hit or miss, each creature within 10 feet of the target must make a Dexterity saving throw. Each of these creatures takes 2d8 lightning damage on a failed save, or half as much damage on a successful one. The piece of ammunition or weapon then returns to its normal form.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the damage for both effects of the spell increases by 1d8 for each slot level above 3rd.</p>
@@ -4443,7 +4443,7 @@
 		</setters>
 	</element>
 	<element name="Lightning Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_LIGHTNING_BOLT">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A stroke of lightning forming a line of 100 feet long and 5 feet wide blasts out from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 8d6 lightning damage on a failed save, or half as much damage on a successful one. The lightning ignites flammable objects in the area that aren’t being worn or carried.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for each slot above 3rd.</p>
@@ -4586,7 +4586,7 @@
 		</setters>
 	</element>
 	<element name="Magic Circle" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MAGIC_CIRCLE">
-		<supports>Cleric, Paladin, Warlock, Wizard</supports>
+		<supports>Cleric, Paladin, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a 10-foot-radius, 20-foot-tall cylinder of magical energy centered on a point on the ground that you can see within range. Glowing runes appear wherever the cylinder intersects with the floor or other surface. Choose one or more of the following types of creatures: celestials, elementals, fey, fiends, or undead. The circle affects a creature of the chosen type in the following ways:</p>
 			<ul>
@@ -4612,7 +4612,7 @@
 		</setters>
 	</element>
 	<element name="Magic Jar" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MAGIC_JAR">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Your body falls into a catatonic state as your soul leaves it and enters the container you used for the spell’s material component. While your soul inhabits the container, you are aware of your surroundings as if you were in the container’s space. You can’t move or use reactions. The only action you can take is to project your soul up to 100 feet out of the container, either returning to your living body (and ending the spell) or attempting to possess a humanoids body.   You can attempt to possess any humanoid within 100 feet of you that you can see (creatures warded by a protection from evil and good or magic circle spells can’t be possessed). The target must make a Charisma saving throw. On a failure, your soul moves into the target’s body, and the target’s soul becomes trapped in the container. On a success, the target resists your efforts to possess it, and you can’t attempt to possess it again for 24 hours.   Once you possess a creature’s body, you control it. Your game statistics are replaced by the statistics of the creature though you retain your alignment and your Intelligence, Wisdom, and Charisma scores. You retain the benefit of your own class feature. If the target has any class levels, you can’t use any of its class features.   Meanwhile, the possessed creature’s soul can perceive from the container using its own senses, but it can’t move or take actions at all.   While possessing a body, you can use your action to return from the host body to the container if it is within 100 feet of you, returning the host creature’s soul to its body. If the host body dies while you’re in it, the creature dies, and you must make a Charisma saving throw against your own spellcasting DC. On a success, you return to the container if it is within 100 feet of you. Otherwise, you die.   If the container is destroyed or the spell ends, your soul immediately returns to your body. If your body is more than 100 feet away from you, or if your body is dead when you attempt to return to it, you die. If another creature’s soul is in the container when it is destroyed, the creature’s soul returns to its body if the body is alive and within 100 feet. Otherwise, that creature dies.   When the spell ends, the container is destroyed.</p>
 		</description>
@@ -4779,7 +4779,7 @@
 		</setters>
 	</element>
 	<element name="Mass Suggestion" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MASS_SUGGESTION">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You suggest a course of activity (limited to a sentence or two) and magically influence up to twelve creatures of your choice that you can see within range and that can hear and understand you. Creatures that can’t be charmed are immune to this effect. The suggestion must be worded in such a manner as to make the course of action sound reasonable. Asking the creature to stab itself, throw itself onto a spear, immolate itself, or do some other obviously harmful act automatically negates the effect of the spell.    Each target must make a Wisdom saving throw. On a failed save, it pursues the course of action you described to the best of its ability. The suggested course of action can continue for the entire duration. If the suggested activity can be completed in a shorter time, the spell ends when the subject finishes what it was asked to do.    You can also specify conditions that will trigger a special activity during the duration. For example, you might suggest that a group of soldiers give all their money to the first beggar they meet. If the condition isn’t met before the spell ends, the activity isn’t performed.    If you or any of your companions damage a creature affected by this spell, the spell ends for that creature.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a 7th-level spell slot, the duration is 10 days. When you use an 8th-level spell slot, the duration is 30 days. When you use a 9th-level spell slot, the duration is a year and a day.</p>
@@ -4840,7 +4840,7 @@
 		</setters>
 	</element>
 	<element name="Melf’s Acid Arrow" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MELFS_ACID_ARROW">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Attack</supports>
 		<description>
 			<p>A shimmering green arrow streaks toward a target within range and bursts in a spray of acid. Make a ranged spell attack against the target. On a hit, the target takes 4d4 acid damage immediately and 2d4 acid damage at the end of its next turn. On a miss, the arrow splashes the target with acid for half as much of the initial damage and no damage at the end of its next turn.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage (both initial and later) increases by 1d4 for each slot level above 2nd.</p>
@@ -4901,7 +4901,7 @@
 		</setters>
 	</element>
 	<element name="Meteor Swarm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_METEOR_SWARM">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Blazing orbs of fire plummet to the ground at four different points you can see within range. Each creature in a 40-foot-radius sphere centered on each point you choose must make a Dexterity saving throw. The sphere spreads around corners. A creature takes 20d6 fire damage and 20d6 bludgeoning damage on a failed save, or half as much damage on a successful one. A creature in the area of more than one fiery burst is affected only once. The spell damages objects in the area and ignites flammable objects that aren’t being worn or carried.</p>
 		</description>
@@ -5041,7 +5041,7 @@
 		</setters>
 	</element>
 	<element name="Modify Memory" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MODIFY_MEMORY">
-		<supports>Bard, Wizard</supports>
+		<supports>Bard, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You attempt to reshape another creature’s memories. One creature that you can see must make a Wisdom saving throw. If you are fighting the creature, it has advantage on the saving throw. On a failed save, the target becomes charmed by you for the duration. The charmed target is incapacitated and unaware of its surroundings, though it can still hear you. If it takes any damage or is targeted by another spell, this spell ends, and none of the target’s memories are modified.</p>
 			<p class="indent">While this charm lasts, you can affect the target’s memory of an event that it experienced within the last 24 hours and that lasted no more than 10 minutes. You can permanently eliminate all memory of the event, allow the target to recall the event with perfect clarity and exacting detail, change its memory of the details of the event, or create a memory of some other event.</p>
@@ -5066,7 +5066,7 @@
 		</setters>
 	</element>
 	<element name="Moonbeam" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MOONBEAM">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>A silvery beam of pale light shines down in a 5-footradius, 40-foot-high cylinder centered on a point within range. Until the spell ends, dim light fills the cylinder.</p>
 			<p class="indent">When a creature enters the spell’s area for the first time on a turn or starts its turn there, it is engulfed in ghostly flames that cause searing pain, and it must make a Constitution saving throw. It takes 2d10 radiant damage on a failed save, or half as much damage on a successful one.</p>
@@ -5162,7 +5162,7 @@
 		</setters>
 	</element>
 	<element name="Mordenkainen’s Sword" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_MORDENKAINENS_SWORD">
-		<supports>Bard, Wizard</supports>
+		<supports>Bard, Wizard, Spell Attack</supports>
 		<description>
 			<p>You create a sword-shaped plane of force that hovers within range. It lasts for the duration.</p>
 			<p>When the sword appears, you make a melee spell attack against a target of your choice within 5 feet of the sword. On a hit, the target takes 3d10 force damage. Until the spell ends, you can use a bonus action on each of your turns to move the sword up to 20 feet to a spot you can see and repeat this attack against the same target or a different one.</p>
@@ -5243,7 +5243,7 @@
 		</setters>
 	</element>
 	<element name="Otiluke’s Freezing Sphere" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_OTILUKES_FREEZING_SPHERE">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A frigid globe of cold energy streaks from your fingertips to a point of your choice within range, where it explodes in a 60-foot-radius sphere. Each creature within the area must make a Constitution saving throw. On a failed save, a creature takes 10d6 cold damage. On a successful save, it takes half as much damage. If the globe strikes a body of water or a liquid that is principally water (not including water-based creatures), it freezes the liquid to a depth of 6 inches over an area 30 feet square. This ice lasts for 1 minute. Creatures that were swimming on the surface of frozen water are trapped in the ice. A trapped creature can use an action to make a Strength check against your spell save DC to break free. You can refrain from firing the globe after completing the spell, if you wish. A small globe about the size of a sling stone, cool to the touch, appears in your hand. At any time, you or a creature you give the globe to can throw the globe (to a range of 40 feet) or hurl it with a sling (to the sling’s normal range). It shatters on impact, with the same effect as the normal casting of the spell. You can also set the globe down without shattering it. After 1 minute, if the globe hasn’t already shattered, it explodes.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 7th level or higher, the damage increases by 1d6 for each slot level above 6th
@@ -5265,7 +5265,7 @@
 		</setters>
 	</element>
 	<element name="Otiluke’s Resilient Sphere" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_OTILUKES_RESILIENT_SPHERE">
-		<supports>Wizard, Artificer</supports>
+		<supports>Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>A sphere of shimmering force encloses a creature or object of Large size or smaller within range. An unwilling creature must make a Dexterity saving throw. On a failed save, the creature is enclosed for the duration. Nothing—not physical objects, energy, or other spell effects—can pass through the barrier, in or out, though a creature in the sphere can breathe there. The sphere is immune to all damage, and a creature or object inside can’t be damaged by attacks or effects originating from outside, nor can a creature inside the sphere damage anything outside it. The sphere is weightless and just large enough to contain the creature or object inside. An enclosed creature can use its action to push against the sphere’s walls and thus roll the sphere at up to half the creature’s speed. Similarly, the globe can be picked up and moved by other creatures. A disintegrate spell targeting the globe destroys it without harming anything inside it.</p>
 		</description>
@@ -5285,7 +5285,7 @@
 		</setters>
 	</element>
 	<element name="Otto’s Irresistible Dance" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_OTTOS_IRRESISTIBLE_DANCE">
-		<supports>Bard, Wizard</supports>
+		<supports>Bard, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose one creature that you can see within range. The target begins a comic dance in place: shuffling, tapping its feet, and capering for the duration. Creatures that can’t be charmed are immune to this spell. A dancing creature must use all its movement to dance without leaving its space and has disadvantage on Dexterity saving throws and attack rolls. While the target is affected by this spell, other creatures have advantage on attack rolls against it. As an action, a dancing creature makes a Wisdom saving throw to regain control of itself. On a successful save, the spell ends.</p>
 		</description>
@@ -5345,7 +5345,7 @@
 		</setters>
 	</element>
 	<element name="Phantasmal Force" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PHANTASMAL_FORCE">
-		<supports>Bard, Sorcerer, Wizard</supports>
+		<supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You craft an illusion that takes root in the mind of a creature that you can see within range. The target must make an Intelligence saving throw. On a failed save, you create a phantasmal object, creature, or other visible phenomenon of your choice that is no larger than a 10-foot cube and that is perceivable only to the target for the duration. This spell has no effect on undead or constructs. The phantasm includes sound, temperature, and other stimuli, also evident only to the creature. The target can use its action to examine the phantasm with an Intelligence (Investigation) check against your spell save DC. If the check succeeds, the target realizes that the phantasm is an illusion, and the spell ends. While a target is affected by the spell, the target treats the phantasm as if it were real. The target rationalizes any illogical outcomes from interacting with the phantasm. For example, a target attempting to walk across a phantasmal bridge that spans a chasm falls once it steps onto the bridge. If the target survives the fall, it still believes that the bridge exists and comes up with some other explanation for its fall—it was pushed, it slipped, or a strong wind might have knocked it off. An affected target is so convinced of the phantasm’s reality that it can even take damage from the illusion. A phantasm created to appear as a creature can attack the target. Similarly, a phantasm created to appear as fire, a pool of acid, or lava can burn the target. Each round on your turn, the phantasm can deal 1d6 psychic damage to the target if it is in the phantasm’s area or within 5 feet of the phantasm, provided that the illusion is of a creature or hazard that could logically deal damage, such as by attacking. The target perceives the damage as a type appropriate to the illusion.</p>
 		</description>
@@ -5365,7 +5365,7 @@
 		</setters>
 	</element>
 	<element name="Phantasmal Killer" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PHANTASMAL_KILLER">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a Wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the end of each of the target’s turns before the spell ends, the target must succeed on a Wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th.</p>
@@ -5426,7 +5426,7 @@
 		</setters>
 	</element>
 	<element name="Planar Binding" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PLANAR_BINDING">
-		<supports>Bard, Cleric, Druid, Wizard</supports>
+		<supports>Bard, Cleric, Druid, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>With this spell, you attempt to bind a celestial, an elemental, a fey, or a fiend to your service. The creature must be within range for the entire casting of the spell. (Typically, the creature is first summoned into the center of an inverted magic circle in order to keep it trapped while this spell is cast.) At the completion of the casting, the target must make a Charisma saving throw. On a failed save, it is bound to serve you for the duration. If the creature was summoned or created by another spell, that spell’s duration is extended to match the duration of this spell. A bound creature must follow your instructions to the best of its ability. You might command the creature to accompany you on an adventure, to guard a location, or to deliver a message. The creature obeys the letter of your instructions, but if the creature is hostile to you, it strives to twist your words to achieve its own objectives. If the creature carries out your instructions completely before the spell ends, it travels to you to report this fact if you are on the same plane of existence. If you are on a different plane of existence, it returns to the place where you bound it and remains there until the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of a higher level, the duration increases to 10 days with a 6th-level slot, to 30 days with a 7th-level slot, to 180 days with an 8th-level slot, and to a year and a day with a 9th-level spell slot.</p>
@@ -5447,7 +5447,7 @@
 		</setters>
 	</element>
 	<element name="Plane Shift" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PLANE_SHIFT">
-		<supports>Cleric, Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Cleric, Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You and up to eight willing creatures who link hands in a circle are transported to a different plane of existence. You can specify a target destination in general terms, such as the City of Brass on the Elemental Plane of Fire or the palace of Dispater on the second level of the Nine Hells, and you appear in or near that destination. If you are trying to reach the City of Brass, for example, you might arrive in its Street of Steel, before its Gate of Ashes, or looking at the city from across the Sea of Fire, at the DM’s discretion.</p>
 			<p class="indent">Alternatively, if you know the sigil sequence of a teleportation circle on another plane of existence, this spell can take you to that circle. If the teleportation circle is too small to hold all the creatures you transported, they appear in the closest unoccupied spaces next to the circle.</p>
@@ -5492,7 +5492,7 @@
 		</setters>
 	</element>
 	<element name="Poison Spray" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_POISON_SPRAY">
-		<supports>Druid, Sorcerer, Warlock, Wizard, Artificer</supports>
+		<supports>Druid, Sorcerer, Warlock, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage. This spell’s damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12).</p>
 		</description>
@@ -5512,7 +5512,7 @@
 		</setters>
 	</element>
 	<element name="Polymorph" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_POLYMORPH">
-		<supports>Bard, Druid, Sorcerer, Wizard</supports>
+		<supports>Bard, Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>This spell transforms a creature that you can see within range into a new form. An unwilling creature must make a Wisdom saving throw to avoid the effect. The spell has no effect on a shapechanger or a creature with 0 hit points.</p>
 			<p class="indent">The transformation lasts for the duration, or until the target drops to 0 hit points or dies. The new form can be any beast whose challenge rating is equal to or less than the target’s (or the target’s level, if it doesn’t have a challenge rating). The target’s game statistics, including mental ability scores, are replaced by the statistics of the chosen beast. It retains its alignment and personality.</p>
@@ -5576,7 +5576,7 @@
 		</setters>
 	</element>
 	<element name="Power Word Stun" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_POWER_WORD_STUN">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You speak a word of power that can overwhelm the mind of one creature you can see within range, leaving it dumbfounded. If the target has 150 hit points or fewer, it is stunned. Otherwise, the spell has no effect. The stunned target must make a Constitution saving throw at the end of each of its turns. On a successful save, this stunning effect ends.</p>
 		</description>
@@ -5646,7 +5646,7 @@
 		</setters>
 	</element>
 	<element name="Prismatic Spray" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PRISMATIC_SPRAY">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Eight multicolored rays of light flash from your hand. Each ray is a different color and has a different power and purpose. Each creature in a 60-foot cone must make a Dexterity saving throw. For each target, roll a d8 to determine which color ray affects it.</p>
 			<p class="indent"><b><i>1. Red.</i></b>The target takes 10d6 fire damage on a failed save, or half as much damage on a successful one.</p>
@@ -5674,7 +5674,7 @@
 		</setters>
 	</element>
 	<element name="Prismatic Wall" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PRISMATIC_WALL">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A shimmering, multicolored plane of light forms a vertical opaque wall—up to 90 feet long, 30 feet high, and 1 inch thick—centered on a point you can see within range. Alternatively, you can shape the wall into a sphere up to 30 feet in diameter centered on a point you choose within range. The wall remains in place for the duration. If you position the wall so that it passes through a space occupied by a creature, the spell fails, and your action and the spell slot are wasted.</p>
 			<p class="indent">The wall sheds bright light out to a range of 100 feet and dim light for an additional 100 feet. You and creatures you designate at the time you cast the spell can pass through and remain near the wall without harm. If another creature that can see the wall moves to within 20 feet of it or starts its turn there, the creature must succeed on a Constitution saving throw or become blinded for 1 minute.</p>
@@ -5705,7 +5705,7 @@
 		</setters>
 	</element>
 	<element name="Produce Flame" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_PRODUCE_FLAME">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Attack</supports>
 		<description>
 			<p>A flickering flame appears in your hand. The flame remains there for the duration and harms neither you nor your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet. The spell ends if you dismiss it as an action or if you cast it again. You can also attack with the flame, although doing so ends the spell. When you cast this spell, or as an action on a later turn, you can hurl the flame at a creature within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 fire damage. This spell’s damage increases by 1d8 when you reach 5th level (2d8),  11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -5885,7 +5885,7 @@
 		</setters>
 	</element>
 	<element name="Ray of Enfeeblement" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_RAY_OF_ENFEEBLEMENT">
-		<supports>Warlock, Wizard</supports>
+		<supports>Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A black beam of enervating energy springs from your finger toward a creature within range. Make a ranged spell attack against the target. On a hit, the target deals only half damage with weapon attacks that use Strength until the spell ends. At the end of each of the target’s turns, it can make a Constitution saving throw against the spell. On a success, the spell ends.</p>
 		</description>
@@ -5905,7 +5905,7 @@
 		</setters>
 	</element>
 	<element name="Ray of Frost" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_RAY_OF_FROST">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Attack</supports>
 		<description>
 			<p>A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn. The spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -5925,7 +5925,7 @@
 		</setters>
 	</element>
 	<element name="Ray of Sickness" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_RAY_OF_SICKNESS">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>A ray of sickening greenish energy lashes out toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and must make a Constitution saving throw. On a failed save, it is also poisoned until the end of your next turn.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.</p>
@@ -6066,7 +6066,7 @@
 		</setters>
 	</element>
 	<element name="Reverse Gravity" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_REVERSE_GRAVITY">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>This spell reverses gravity in a 50-foot-radius, 100-foot high cylinder centered on a point within range. All creatures and objects that aren’t somehow anchored to the ground in the area fall upward and reach the top of the area when you cast this spell. A creature can make a Dexterity saving throw to grab onto a fixed object it can reach, thus avoiding the fall. If some solid object (such as a ceiling) is encountered in this fall, falling objects and creatures strike it just as they would during a normal downward fall. If an object or creature reaches the top of the area without striking anything, it remains there, oscillating slightly, for the duration. At the end of the duration, affected objects and creatures fall back down.</p>
 		</description>
@@ -6126,7 +6126,7 @@
 		</setters>
 	</element>
 	<element name="Sacred Flame" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SACRED_FLAME">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>Flame-like radiance descends on a creature that you can see within range. The target must succeed on a Dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw. The spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -6146,7 +6146,7 @@
 		</setters>
 	</element>
 	<element name="Sanctuary" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SANCTUARY">
-		<supports>Cleric, Artificer</supports>
+		<supports>Cleric, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>You ward a creature within range against attack. Until the spell ends, any creature who targets the warded creature with an attack or a harmful spell must first make a Wisdom saving throw. On a failed save, the creature must choose a new target or lose the attack or spell. This spell doesn’t protect the warded creature from area effects, such as the explosion of a fireball. If the warded creature makes an attack, casts a spell that affects an enemy, or deals damage to another creature, this spell ends.</p>
 		</description>
@@ -6166,7 +6166,7 @@
 		</setters>
 	</element>
 	<element name="Scorching Ray" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SCORCHING_RAY">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Attack</supports>
 		<description>
 			<p>You create three rays of fire and hurl them at targets within range. You can hurl them at one target or several. Make a ranged spell attack for each ray. On a hit, the target takes 2d6 fire damage.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, you create one additional ray for each slot level above 2nd.</p>
@@ -6187,7 +6187,7 @@
 		</setters>
 	</element>
 	<element name="Scrying" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SCRYING">
-		<supports>Bard, Cleric, Druid, Warlock, Wizard</supports>
+		<supports>Bard, Cleric, Druid, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You can see and hear a particular creature you choose that is on the same plane of existence as you. The target must make a Wisdom saving throw, which is modified by how well you know the target and the sort of physical connection you have to it. If a target knows you’re casting this spell, it can fail the saving throw voluntarily if it wants to be observed. Knowledge -- Save Modifier Secondhand (you have heard of the target) -- +5 Firsthand (you have met the target) +0 Familiar (you know the target well) -- -5 Connection -- Save Modifier Likeness or picture -- -2 Possession or garment -- -4 Body part, lock of hair, bit of nail, or the like -- -10 On a successful save, the target isn’t affected, and you can’t use this spell against it again for 24 hours.   On a failed save, the spell creates an invisible sensor within 10 feet of the target. You can see and hear through the sensor as if you were there. The sensor moves with the target, remaining within 10 feet of it for the duration. A creature that can see invisible objects sees the sensor as a luminous orb about the size of your fist.   Instead of targeting a creature, you can choose a location you have seen before as the target of this spell. When you do, the sensor appears at that location and doesn’t move.</p>
 		</description>
@@ -6207,7 +6207,7 @@
 		</setters>
 	</element>
 	<element name="Searing Smite" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SEARING_SMITE">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you hit a creature with a melee weapon attack during the spell’s duration, your weapon flares with white-hot intensity, and the attack deals an extra 1d6 fire damage to the target and causes the target to ignite in flames. At the start of each of its turns until the spell ends, the target must make a Constitution saving throw. On a failed save, it takes 1d6 fire damage. On a successful save, the spells ends. If the target or a creature within 5 feet of it uses an action to put out the flames, or if some other effect douses the flames (such as the target being submerged in water), the spell ends.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the initial extra damage dealt by the attack increases by 1d6 for each slot level above 1st.</p>
@@ -6248,7 +6248,7 @@
 		</setters>
 	</element>
 	<element name="Seeming" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SEEMING">
-		<supports>Bard, Sorcerer, Wizard</supports>
+		<supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>This spell allows you to change the appearance of any number of creatures that you can see within range. You give each target you choose a new, illusory appearance. An unwilling target can make a Charisma saving throw, and if it succeeds, it is unaffected by this spell. The spell disguises physical appearances as well as clothing, armor, weapons, and equipment. You can make each creature seem 1 foot shorter or taller and appear thin, fat, or in between. You can’t change a target’s body type, so you must choose a form that has the same basic arrangement of limbs. Otherwise, the extent of the illusion is up to you. The spell lasts for the duration, unless you use your action to dismiss it sooner. The changes wrought by this spell fail to hold up to physical inspections. For example, if you use this spell to add a hat to a creature’s outfit objects pass through the hat, and anyone who touches it would feel nothing or would feel the creature’s head and hair. If you use this spell to appear thinner then you are, the hand of someone who reaches out to touch you would bump into you while it was seemingly still in midair. A creature can use its action to inspect a target and make an Intelligence (Investigation) check against your spell save DC. If it succeeds, it becomes aware that the target is disguised.</p>
 		</description>
@@ -6328,7 +6328,7 @@
 		</setters>
 	</element>
 	<element name="Shatter" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SHATTER">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A sudden loud ringing noise, painfully intense, erupts from a point of your choice within range. Each creature in a 10-foot-radius sphere centered on that point must make a Constitution saving throw. A creature takes 3d8 thunder damage on a failed save, or half as much damage on a successful one. A creature made of inorganic material such as stone, crystal, or metal has disadvantage on this saving throw. A nonmagical object that isn’t being worn or carried also takes the damage if it’s in the spell’s area.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</p>
@@ -6409,7 +6409,7 @@
 		</setters>
 	</element>
 	<element name="Shocking Grasp" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SHOCKING_GRASP">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Attack</supports>
 		<description>
 			<p>Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can’t take reactions until the start of its next turn.</p>
 			<p class="indent">The spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
@@ -6518,7 +6518,7 @@
 		</setters>
 	</element>
 	<element name="Sleet Storm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SLEET_STORM">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Until the spell ends, freezing rain and sleet fall in a 20-foot-tall cylinder with a 40-foot radius centered on a point you choose within range. The area is heavily obscured, and exposed flames in the area are doused.</p>
 			<p class="indent">The ground in the area is covered with slick ice, making it difficult terrain. When a creature enters the spell’s area for the first time on a turn or starts its turn there, it must make a Dexterity saving throw. On a failed save, it falls prone.</p>
@@ -6540,7 +6540,7 @@
 		</setters>
 	</element>
 	<element name="Slow" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SLOW">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You alter time around up to six creatures of your choice in a 40-foot cube within range. Each target must succeed on a Wisdom saving throw or be affected by this spell for the duration.</p>
 			<p class="indent">An affected target’s speed is halved, it takes a -2 penalty to AC and Dexterity saving throws, and it can’t use reactions. On its turn, it can use either an action or a bonus action, not both. Regardless of the creature’s abilities or magic items, it can’t make more than one melee or ranged attack during its turn.</p>
@@ -6683,7 +6683,7 @@
 		</setters>
 	</element>
 	<element name="Spirit Guardians" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SPIRIT_GUARDIANS">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Saving Throw</supports>
 		<description>
 			<p>You call forth spirits to protect you. They flit around you to a distance of 15 feet for the duration. If you are good or neutral, their spectral form appears angelic or fey (your choice). If you are evil, they appear fiendish. When you cast this spell, you can designate any number of creatures you can see to be unaffected by it. An affected creature’s speed is halved in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a Wisdom saving throw. On a failed save, the creature takes 3d8 radiant damage (if you are good or neutral) or 3d8 necrotic damage (if you are evil). On a successful save, the creature takes half as much damage.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d8 for each slot level above 3rd.</p>
@@ -6704,7 +6704,7 @@
 		</setters>
 	</element>
 	<element name="Spiritual Weapon" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SPIRITUAL_WEAPON">
-		<supports>Cleric</supports>
+		<supports>Cleric, Spell Attack</supports>
 		<description>
 			<p>You create a floating, spectral weapon within range that lasts for the duration or until you cast this spell again. When you cast the spell, you can make a melee spell attack against a creature within 5 feet of the weapon. On a hit, the target takes force damage equal to 1d8 + your spellcasting ability modifier. As a bonus action on your turn, you can move the weapon up to 20 feet and repeat the attack against a creature within 5 feet of it. The weapon can take whatever form you choose. Clerics of deities who are associated with a particular weapon (as St. Cuthbert is known for his mace and Thor for his hammer) make this spell’s effect resemble that weapon.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for every two slot levels above the 2nd.</p>
@@ -6725,7 +6725,7 @@
 		</setters>
 	</element>
 	<element name="Staggering Smite" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_STAGGERING_SMITE">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you hit a creature with a melee weapon attack during this spell’s duration, your weapon pierces both body and mind, and the attack deals an extra 4d6 psychic damage to the target. The target must make a Wisdom saving throw. On a failed save, it has disadvantage on attack rolls and ability checks, and can’t take reactions, until the end of its next turn.</p>
 		</description>
@@ -6745,7 +6745,7 @@
 		</setters>
 	</element>
 	<element name="Stinking Cloud" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_STINKING_CLOUD">
-		<supports>Bard, Sorcerer, Wizard</supports>
+		<supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a 20-foot-radius sphere of yellow, nauseating gas centered on a point within range. The cloud spreads around corners, and its area is heavily obscured. The cloud lingers in the air for the duration. Each creature that is completely within the cloud at the start of its turn must make a Constitution saving throw against poison. On a failed save, the creature spends its action that turn retching and reeling. Creatures that don’t need to breathe or are immune to poison automatically succeed on this saving throw. A moderate wind (at least 10 miles per hour) disperses the cloud after 4 rounds. A strong wind (at least 20 miles per hour) disperses it after 1 round.</p>
 		</description>
@@ -6805,7 +6805,7 @@
 		</setters>
 	</element>
 	<element name="Storm of Vengeance" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_STORM_OF_VENGEANCE">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p class="indent">A churning storm cloud forms, centered on a point you can see and spreading to a radius of 360 feet. Lightning flashes in the area, thunder booms, and strong winds roar. Each creature under the cloud (no more than 5,000 feet beneath the cloud) when it appears must make a Constitution saving throw. On a failed save, a creature takes 2d6 thunder damage and becomes deafened for 5 minutes.</p>
 			<p class="indent">Each round you maintain concentration on this spell, the storm produces different effects on your turn.</p>
@@ -6830,7 +6830,7 @@
 		</setters>
 	</element>
 	<element name="Suggestion" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SUGGESTION">
-		<supports>Bard, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You suggest a course of activity (limited to a sentence or two) and magically influence a creature you can see within range that can hear and understand you. Creatures that can’t be charmed are immune to this effect. The suggestion must be worded in such a manner as to make the course of action sound reasonable. Asking the creature to stab itself, throw itself onto a spear, immolate itself, or do some other obviously harmful act ends the spell.</p>
 			<p class="indent">The target must make a Wisdom saving throw. On a failed save, it purses the course of action you described to the best of its ability. The suggested course of action can continue for the entire duration. If the suggested activity can be completed in a shorter time, the spell ends when the subject finishes what it was asked to do.</p>
@@ -6853,7 +6853,7 @@
 		</setters>
 	</element>
 	<element name="Sunbeam" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SUNBEAM">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A beam of brilliant light flashes out from your hand in a 5-foot-wide, 60-foot-line. Each creature in the line must make a Constitution saving throw. On a failed save, a creature takes 6d8 radiant damage and is blinded until your next turn. On a successful save, it takes half as much damage and isn’t blinded by this spell. Undead and oozes have disadvantage on this saving throw. You can create a new line of radiance as your action on any turn until the spell ends. For the duration, a mote of brilliant radiance shines in your hand. It sheds bright light in a 30-foot radius and dim light for an additional 30 feet. The light is sunlight.</p>
 		</description>
@@ -6873,7 +6873,7 @@
 		</setters>
 	</element>
 	<element name="Sunburst" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SUNBURST">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Brilliant sunlight flashes in a 60-foot radius centered on a point you choose within range. Each creature in that light must make a Constitution saving throw. On a failed save, a creature takes 12d6 radiant damage and is blinded for 1 minute. On a successful save, it takes half as much damage and isn’t blinded by this spell. Undead and oozes have disadvantage on this saving throw.  A creature blinded by this spell makes another Constitution saving throw at the end of each of its turns. On a successful save, it is no longer blinded.  This spell dispels any darkness in its area that was created by a spell.</p>
 		</description>
@@ -6933,7 +6933,7 @@
 		</setters>
 	</element>
 	<element name="Tasha’s Hideous Laughter" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_TASHAS_HIDEOUS_LAUGHTER">
-		<supports>Bard, Wizard</supports>
+		<supports>Bard, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A creature of your choice that you can see within range perceives everything as hilariously funny and falls into fits of laughter if this spell affects it. The target must succeed on a Wisdom saving throw or fall prone, becoming incapacitated and unable to stand up for the duration. A creature with an Intelligence score of 4 or less isn’t affected.</p>
 			<p class="indent">At the end of each of its turns, and each time it takes damage, the target can make another Wisdom saving throw. The target has advantage on the saving throw if it’s triggered by damage. On a success, the spell ends.</p>
@@ -7107,7 +7107,7 @@
 		</setters>
 	</element>
 	<element name="Thorn Whip" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_THORN_WHIP">
-		<supports>Druid, Artificer</supports>
+		<supports>Druid, Artificer, Spell Attack</supports>
 		<description>
 			<p>You create a long, vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes 1d6 piercing damage, and if the creature is Large or smaller, you pull the creature up to 10 feet closer to you. This spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
 		</description>
@@ -7127,7 +7127,7 @@
 		</setters>
 	</element>
 	<element name="Thunderous Smite" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_THUNDEROUS_SMITE">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>The first time you hit with a melee weapon attack during this spell’s duration, your weapon rings with thunder that is audible within 300 feet of you, and the attack deals an extra 2d6 thunder damage to the target. Additionally, if the target is a creature, it must succeed on a Strength saving throw or be pushed 10 feet away from you and knocked prone.</p>
 		</description>
@@ -7147,7 +7147,7 @@
 		</setters>
 	</element>
 	<element name="Thunderwave" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_THUNDERWAVE">
-		<supports>Bard, Druid, Sorcerer, Wizard</supports>
+		<supports>Bard, Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A wave of thunderous force sweeps out from you. Each creature in a 15-foot cube originating from you must make a Constitution saving throw. On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful save, the creature takes half as much damage and isn’t pushed. In addition, unsecured objects that are completely within the area of effect are automatically pushed 10 feet away from you by the spell’s effect, and the spell emits a thunderous boom audible out to 300 feet.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.</p>
@@ -7249,7 +7249,7 @@
 		</setters>
 	</element>
 	<element name="True Polymorph" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_TRUE_POLYMORPH">
-		<supports>Bard, Warlock, Wizard</supports>
+		<supports>Bard, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose one creature or nonmagical object that you can see within range. You transform the creature into a different creature, the creature into a nonmagical object, or the object into a creature (the object must be neither worn nor carried by another creature). The transformation lasts for the duration, or until the target drops to 0 hit points or dies. If you concentrate on this spell for the full duration, the transformation becomes permanent.</p>
 			<p class="indent">This spell has no effect on a shapechanger or a creature with 0 hit points. An unwilling creature can make a Wisdom saving throw, and if it succeeds, it isn’t affected by this spell.</p>
@@ -7339,7 +7339,7 @@
 		</setters>
 	</element>
 	<element name="Tsunami" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_TSUNAMI">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>A wall of water springs into existence at a point you choose within range. You can make the wall up to 300 feet long, 300 feet high, and 50 feet thick. The wall lasts for the duration. When the wall appears, each creature within its area must make a Strength saving throw. On a failed save, a creature takes 6d10 bludgeoning damage, or half as much damage on a successful save. At the start of each of your turns after the wall appears, the wall, along with any creatures in it, moves 50 feet away from you. Any Huge or smaller creature inside the wall or whose space the wall enters when it moves must succeed on a Strength saving throw or take 5d10 bludgeoning damage. A creature can take this damage only once per round. At the end of the turn, the wall’s height is reduced by 50 feet, and the damage creatures take from the spell on subsequent rounds is reduced by 1d10. When the wall reaches 0 feet in height, the spell ends. A creature caught in the wall can move by swimming. Because of the force of the wave, though, the creature must make a successful Strength (Athletics) check against your spell save DC in order to move at all. If it fails the check, it can’t move. A creature that moves out of the area falls to the ground.</p>
 		</description>
@@ -7381,7 +7381,7 @@
 		</setters>
 	</element>
 	<element name="Vampiric Touch" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_VAMPIRIC_TOUCH">
-		<supports>Warlock, Wizard</supports>
+		<supports>Warlock, Wizard, Spell Attack</supports>
 		<description>
 			<p>The touch of your shadow-wreathed hand can siphon force from others to heal your wounds. Make a melee spell attack against a creature within your reach. On a hit, the target takes 3d6 necrotic damage, and you regain hit points equal to half the amount of necrotic damage dealt. Until the spell ends, you can make the attack again on each of your turns as an action.  </p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for each slot level above 3rd.</p>
@@ -7402,7 +7402,7 @@
 		</setters>
 	</element>
 	<element name="Vicious Mockery" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_VICIOUS_MOCKERY">
-		<supports>Bard</supports>
+		<supports>Bard, Spell Saving Throw</supports>
 		<description>
 			<p>You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (thought it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.   This spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4) and 17th level (4d4)</p>
 		</description>
@@ -7422,7 +7422,7 @@
 		</setters>
 	</element>
 	<element name="Wall of Fire" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WALL_OF_FIRE">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a wall of fire on a solid surface within range. You can make the wall up to 60 feet long, 20 feet high, and 1 foot think, or a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot think. The wall is opaque and lasts for the duration.</p>
 		<p class="indent">When the wall appears, each creature within its area must make a Dexterity saving throw. On a failed save, a creature takes 5d8 fire damage, or half as much damage on a successful save.</p>
@@ -7466,7 +7466,7 @@
 		</setters>
 	</element>
 	<element name="Wall of Ice" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WALL_OF_ICE">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a wall of ice on a solid surface within range. You can form it into a hemispherical dome or a sphere with radium of up to 10 feet, or you can shape a flat surface made up of ten 10-foot-square panels. Each panel must be contiguous with another panel. In any form, the wall is 1 foot thick and lasts for the duration.</p>
 		<p class="indent">If the wall cuts through a creature’s space when it appears, the creature within its area is pushed to one side of the wall and must make a Dexterity saving throw. On a failed save, the creature takes 10d6 cold damage, or half as much damage on a successful save.</p>
@@ -7489,7 +7489,7 @@
 		</setters>
 	</element>
 	<element name="Wall of Stone" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WALL_OF_STONE">
-		<supports>Druid, Sorcerer, Wizard, Artificer</supports>
+		<supports>Druid, Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>A nonmagical wall of solid stone springs into existence at a point you choose within range. The wall is 6 inches thick and is composed of ten 10-foot-by-10-foot panels. Each panel must be contiguous with at least on other panel. Alternatively, you can create 10-foot-by-20-foot panels that are only 3 inches thick.</p>
 		<p class="indent">If the wall cuts through a creature’s space when it appears, the creature is pushed to one side of the wall (your choice). If a creature would be surrounded on all sides by the wall (or the wall and another solid surface), that creature can make a Dexterity saving throw. On a success, it can use its reaction to move up to its speed so that it is no longer enclosed by the wall.</p>
@@ -7514,7 +7514,7 @@
 		</setters>
 	</element>
 	<element name="Wall of Thorns" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WALL_OF_THORNS">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>You create a wall of tough, pliable, tangled brush bristling with needle-sharp thorns. The wall appears within range on a solid surface and lasts for the duration. You choose to make the wall up to 60 feet long, 10 feet high, and 5 feet thick or a circle that has a 20-foot diameter and is up to 20 feet high and 5 feet thick. The wall blocks line of sight.</p>
 		<p class="indent">When the wall appears, each creature within its area must make a Dexterity saving throw. On a failed save, a creature takes 7d8 piercing damage, or half as much damage on a successful save.</p>
@@ -7599,7 +7599,7 @@
 		</setters>
 	</element>
 	<element name="Web" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WEB">
-		<supports>Sorcerer, Wizard, Artificer</supports>
+		<supports>Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
 		<description>
 			<p>You conjure a mass of thick, sticky webbing at a point of your choice within range. The webs fill a 20-foot cube from that point for the duration. The webs are difficult terrain and lightly obscure their area.</p>
 		<p class="indent">If the webs aren’t anchored between two solid masses (such as walls or trees) or layered across a floor, wall, or ceiling, the conjured web collapses on itself, and the spell ends at the start of your next turn. Webs layered over a flat surface have a depth of 5 feet.</p>
@@ -7623,7 +7623,7 @@
 		</setters>
 	</element>
 	<element name="Weird" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WEIRD">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Drawing on the deepest fears of a group of creatures, you create illusory creatures in their minds, visible only to them. Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a Wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature’s deepest fears, manifesting its worst nightmares as an implacable threat. At the end of each of the frightened creature’s turns, it must succeed on a Wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends for that creature.</p>
 		</description>
@@ -7664,7 +7664,7 @@
 		</setters>
 	</element>
 	<element name="Wind Wall" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WIND_WALL">
-		<supports>Druid, Ranger</supports>
+		<supports>Druid, Ranger, Spell Saving Throw</supports>
 		<description>
 			<p>A wall of strong wind rises from the ground at a point you choose within range. You can make the wall up to 50 feet long, 15 feet high, and 1 foot thick. You can shape the wall in any way you choose so long as it makes one continuous path along the ground. The wall lasts for the duration.</p>
 		<p class="indent">When the wall appears, each creature within its area must make a Strength saving throw. A creature takes 3d8 bludgeoning damage on a failed save, or half as much damage on a successful one.</p>
@@ -7715,7 +7715,7 @@
 		</setters>
 	</element>
 	<element name="Witch Bolt" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WITCH_BOLT">
-		<supports>Sorcerer, Warlock, Wizard</supports>
+		<supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
 		<description>
 			<p>A beam of crackling, blue energy lances out toward a creature within range, forming a sustained arc of lightning between you and the target. Make a ranged spell attack against that creature. On a hit, the target takes 1d12 lightning damage, and on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically. The spell ends if you use your action to do anything else. The spell also ends if the target is ever outside the spell’s range or if it has total cover from you.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 2nd level or higher, the initial damage increases by 1d12 for each slot level above 1st.</p>
@@ -7757,7 +7757,7 @@
 		</setters>
 	</element>
 	<element name="Wrathful Smite" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_WRATHFUL_SMITE">
-		<supports>Paladin</supports>
+		<supports>Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>The next time you hit with a melee weapon attack during this spell’s duration, your attack deals an extra 1d6 psychic damage. Additionally, if the target is a creature, it must make a Wisdom saving throw or be frightened of you until the spell ends. As an action, the creature can make a Wisdom check against your spell save DC to steel its resolve and end this spell.</p>
 		</description>
@@ -7777,7 +7777,7 @@
 		</setters>
 	</element>
 	<element name="Zone of Truth" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_ZONE_OF_TRUTH">
-		<supports>Bard, Cleric, Paladin</supports>
+		<supports>Bard, Cleric, Paladin, Spell Saving Throw</supports>
 		<description>
 			<p>You create a magical zone that guards against deception in a 15-foot-radius sphere centered on a point of your choice within range. Until the spell ends, a creature that enters the spell’s area for the first time on a turn or starts its turn there must make a Charisma saving throw. On a failed save, a creature can’t speak a deliberate lie while in the radius. You know whether each creature succeeds or fails on its saving throw.</p>
 		<p class="indent">An affected creature is aware of the spell and can thus avoid answering questions to which it would normally respond with a lie. Such creatures can be evasive in its answers as long as it remains within the boundaries of the truth.</p>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -1563,7 +1563,7 @@
 		</setters>
 	</element>
 	<element name="Contact Other Plane" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_CONTACT_OTHER_PLANE">
-		<supports>Warlock, Wizard, Spell Saving Throw</supports>
+		<supports>Warlock, Wizard</supports>
 		<description>
 			<p>You mentally contact a demigod, the spirit of a long-dead sage, or some other mysterious entity from another plane. Contacting this extraplanar intelligence can strain or even break your mind. When you cast this spell, make a DC 15 Intelligence saving throw. On a failure, you take 6d6 psychic damage and are insane until you finish a long rest. While insane, you can’t take actions, can’t understand what other creatures say, can’t read, and speak only in gibberish. A greater restoration spell cast on you ends this effect.</p>
 			<p class="indent">On a successful save, you can ask the entity up to five questions. You must ask your questions before the spell ends. The DM answers each question with one word, such as “yes,” “no,” “maybe,” “never,” “irrelevant,” or “unclear” (if the entity doesn’t know the answer to the question). If a one-word answer would be misleading, the DM might instead offer a short phrase as an answer.</p>

--- a/supplements/acquisitions-incorporated/spells.xml
+++ b/supplements/acquisitions-incorporated/spells.xml
@@ -115,7 +115,7 @@
 		</setters>
 	</element>
 	<element name="Jim’s Magic Missile" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_JIMS_MAGIC_MISSILE">
-		<supports>Wizard, Spell Attack</supports>
+		<supports>Wizard, Ranged, Spell Attack</supports>
 		<description>
 			<p>Any apprentice wizard can cast a boring old magic missile. Sure, it always strikes its target. Yawn. Do away with the drudgery of your grandfather’s magic with this improved version of the spell, as used by Jim Darkmagic!</p>
 			<p class="indent">You create three twisting, whistling, hypoallergenic, gluten-free darts of magical force. Each dart targets a creature of your choice that you can see within range. Make a ranged spell attack for each missile. On a hit, a missile deals 2d4 force damage to its target.</p>

--- a/supplements/acquisitions-incorporated/spells.xml
+++ b/supplements/acquisitions-incorporated/spells.xml
@@ -2,12 +2,12 @@
 <elements>
 	<info>
         <name>Spells</name>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/acquisitions-incorporated/spells.xml" />
 		</update>
 	</info>
 	<element name="Distort Value" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_DISTORT_VALUE">
-		<supports>Bard,Sorcerer,Wizard,Warlock</supports>
+		<supports>Bard, Sorcerer, Wizard, Warlock</supports>
 		<description>
 			<p>Do you need to squeeze a few more gold pieces out of a merchant as you try to sell that weird octopus statue you liberated from the chaos temple? Do you need to downplay the worth of some magical assets when the tax collector stops by? Distort value has you covered.</p>
 			<p class="indent">You cast this spell on an object no more than 1 foot on a side, doubling the object’s perceived value by adding illusory nourishes or polish to it, or reducing its perceived value by half with the help of illusory scratches, dents, and other unsightly features. Anyone examining the object can ascertain its true value with a successful Intelligence (Investigation) check against your spell save DC.</p>
@@ -28,7 +28,7 @@
 		</setters>
 	</element>
 	<element name="Fast Friends" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_FAST_FRIENDS">
-		<supports>Bard,Cleric,Wizard</supports>
+		<supports>Bard, Cleric, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>When you need to make sure something gets done, you can’t rely on vague promises, sworn oaths, or binding contracts of employment. When you cast this spell, choose one humanoid within range that can see and hear you, and that can understand you. The creature must succeed on a Wisdom saving throw or become charmed by you for the duration. While the creature is charmed in this way, it undertakes to perform any services or activities you ask of it in a friendly manner, to the best of its ability.</p>
 			<p class="indent">You can set the creature new tasks when a previous task is completed, or if you decide to end its current task. If the service or activity might cause harm to the creature. or if it conflicts with the creature’s normal activities and desires, the creature can make another Wisdom saving throw to try to end the effect. This save is made with advantage if you or your companions are fighting the creature. If the activity would result in certain death for the creature, the spell ends.</p>
@@ -51,7 +51,7 @@
 		</setters>
 	</element>
 	<element name="Gift of Gab" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_GIFT_OF_GAB">
-		<supports>Bard,Wizard</supports>
+		<supports>Bard, Wizard</supports>
 		<description>
 			<p>Jim Darkmagic is said to have invented this spell, originally calling it I said what?! Have you ever been talking to the local monarch and accidentally mentioned how their son looks like your favorite hog from when you were growing up on the family farm? We’ve all been there! But rather than being beheaded for an honest slip of the tongue, you can pretend it never happened—by ensuring that no one knows it happened.</p>
 			<p class="indent">When you cast this spell, you skillfully reshape the memories of listeners in your immediate area, so that each creature of your choice within 5 feet of you forgets everything you said within the last 6 seconds. Those creatures then remember that you actually said the words you speak as the verbal component of the spell.</p>
@@ -73,7 +73,7 @@
 		</setters>
 	</element>
 	<element name="Incite Greed" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_INCITE_GREED">
-		<supports>Cleric,Sorcerer,Wizard,Warlock</supports>
+		<supports>Cleric, Sorcerer, Wizard, Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>When you cast this spell, you present the gem used as the material component and choose any number of creatures within range that can see you. Each target must succeed on a Wisdom saving throw or be charmed by you until the spell ends, or until you or your companions do anything harmful to it. While charmed in this way, a creature can do nothing but use its movement to approach you in a safe manner. While an affected creature is within 5 feet of you, it cannot move, but simply stares greedily at the gem you present.</p>
 			<p class="indent">At the end of each of its turns, an affected target can make a Wisdom saving throw. If it succeeds, this effect ends for that target.</p>
@@ -94,7 +94,7 @@
 		</setters>
 	</element>
 	<element name="Jim’s Glowing Coin" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_JIMS_GLOWING_COIN">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Of the many tactics employed by master magician and renowned adventurer Jim Darkmagic, the old glowing coin trick is a time-honored classic. When you cast the spell, you hurl the coin that is the spell’s material component to any spot within range. The coin lights up as if under the effect of a light spell. Each creature of your choice that you can see within 30 feet of the coin must succeed on a Wisdom saving throw or be distracted for the duration. While distracted, a creature has disadvantage on Wisdom (Perception) checks and initiative rolls.</p>
 		</description>
@@ -115,7 +115,7 @@
 		</setters>
 	</element>
 	<element name="Jim’s Magic Missile" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_JIMS_MAGIC_MISSILE">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Attack</supports>
 		<description>
 			<p>Any apprentice wizard can cast a boring old magic missile. Sure, it always strikes its target. Yawn. Do away with the drudgery of your grandfather’s magic with this improved version of the spell, as used by Jim Darkmagic!</p>
 			<p class="indent">You create three twisting, whistling, hypoallergenic, gluten-free darts of magical force. Each dart targets a creature of your choice that you can see within range. Make a ranged spell attack for each missile. On a hit, a missile deals 2d4 force damage to its target.</p>
@@ -139,7 +139,7 @@
 		</setters>
 	</element>	
 	<element name="Motivational Speech" type="Spell" source="Acquisitions Incorporated" id="ID_WOTC_ACQINC_SPELL_MOTIVATIONAL_SPEECH">
-		<supports>Bard,Cleric</supports>
+		<supports>Bard, Cleric</supports>
 		<description>
 			<p>You address allies, staff, or innocent bystanders to exhort and inspire them to greatness, whether they have anything to get excited about or not. Choose up to five creatures within range that can hear you. For the duration, each affected creature gains 5 temporary hit points and has advantage on Wisdom saving throws. If an affected creature is hit by an attack, it has advantage on the next attack roll it makes. Once an affected creature loses the temporary hit points granted by this spell, the spell ends for that creature.</p>
 			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 4th level or higher, the temporary hit points increase by 5 for each slot level above 3rd.</p>

--- a/supplements/explorers-guide-to-wildemount/spells.xml
+++ b/supplements/explorers-guide-to-wildemount/spells.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-        <update version="0.0.2">
+        <update version="0.0.3">
             <file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/explorers-guide-to-wildemount/spells.xml" />
         </update>
     </info>
     <element name="Dark Star" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_DARK_STAR">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>This spell creates a sphere centered on a point you choose within range. The sphere can have a radius of up to 40 feet. The area within this sphere is filled with magical darkness and crushing gravitational force.</p>
             <p class="indent">For the duration, the spell’s area is difficult terrain. A creature with darkvision can’t see through the magical darkness, and nonmagical light can’t illuminate it. No sound can be created within or pass through the area. Any creature or object entirely inside the sphere is immune to thunder damage, and creatures are deafened while entirely inside it. Casting a spell that includes a verbal component is impossible there.</p>
@@ -70,7 +70,7 @@
         </setters>
     </element>
     <element name="Gravity Fissure" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_GRAVITY_FISSURE">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You manifest a ravine of gravitational energy in a line originating from you that is 100 feet long and 5 feet wide. Each creature in that line must make a Constitution saving throw, taking 8d8 force damage on a failed save, or half as much damage on a successful one.</p>
             <p class="indent">Each creature within 10 feet of the line but not in it must succeed on a Constitution saving throw or take 8d8 force damage and be pulled toward the line until the creature is within its area.</p>
@@ -92,7 +92,7 @@
         </setters>
     </element>
     <element name="Gravity Sinkhole" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_GRAVITY_SINKHOLE">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>A 20-foot-radius sphere of crushing force forms at a point you can see within range and tugs at the creatures there. Each creature within the sphere must make a Constitution saving throw. On a failed save, the creature takes 5d10 force damage and is pulled in a straight line toward the center of the sphere, ending in an unoccupied space as close to the center as possible (even if that space is in the air). On a successful save, the creature takes half as much damage and isn’t pulled.</p>
             <p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th.</p>
@@ -135,7 +135,7 @@
         </setters>
     </element>
     <element name="Magnify Gravity" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_MAGNIFY_GRAVITY">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>The gravity in a 10-foot-radius sphere centered on a point you can see within range increases for a moment. Each creature in the sphere on the turn when you cast the spell must make a Constitution saving throw. On a failed save, a creature takes 2d8 force damage, and its speed is halved until the end of the next turn. On a successful save, a creature takes half as much damage and suffers no reduction to its speed.</p>
             <p class="indent">Until the start of your next turn, any object that isn’t being worn or carried in the sphere requires a successful Strength check against your spell save DC to pick up or move.</p>
@@ -157,7 +157,7 @@
         </setters>
     </element>
     <element name="Pulse Wave" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_PULSE_WAVE">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You create intense pressure, unleash it in a 30-foot cone, and decide whether the pressure pulls or pushes creatures and objects. Each creature in that cone must make a Constitution saving throw. A creature takes 6d6 force damage on a failed save, or half as much damage on a successful one, and every creature that fails the save is either pulled 15 feet toward you or pushed 15 feet away from you, depending on the choice you made for the spell.</p>
             <p class="indent">In addition, unsecured objects that are completely within the cone are likewise pulled or pushed 15 feet.</p>
@@ -179,7 +179,7 @@
         </setters>
     </element>
     <element name="Ravenous Void" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_RAVENOUS_VOID">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You create a 20-foot-radius sphere of destructive gravitational force centered on a point that you can see within range. For the spell’s duration, the sphere and any space within 100 feet of it are difficult terrain, and nonmagical objects fully inside the sphere are destroyed if they aren’t being worn or carried.</p>
             <p class="indent">When the sphere appears and at the start of each of your turns until the spell ends, unsecured objects within 100 feet of the sphere are pulled toward the sphere’s center, ending in an unoccupied space as close to the center as possible.</p>
@@ -201,7 +201,7 @@
         </setters>
     </element>
     <element name="Reality Break" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_REALITY_BREAK">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You shatter the barriers between realities and timelines, thrusting a creature into turmoil and madness. The target must succeed on a Wisdom saving throw, or it can’t take reactions until the spell ends. The affected target must also roll a d10 at the start of each of its turns; the number rolled determines what happens to the target, as shown on the Reality Break Effects table.</p>
             <p class="indent">At the end of each of its turns, the affected target can repeat the Wisdom saving throw, ending the spell on itself on a success.</p>
@@ -231,7 +231,7 @@
         </setters>
     </element>
     <element name="Sapping Sting" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_SAPPING_STING">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You sap the vitality of one creature you can see in range. The target must succeed on a Constitution saving throw or take 1d4 necrotic damage and fall prone.</p>
             <p class="indent">This spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).</p>
@@ -252,7 +252,7 @@
         </setters>
     </element>
     <element name="Temporal Shunt" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_TEMPORAL_SHUNT">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You target the triggering creature, which must succeed on a Wisdom saving throw or vanish, being thrown into another point in time and causing the attack to miss or spell to be wasted. At the start of its next turn, the target reappears where it was or in the closest unoccupied space. The target doesn’t remember you casting the spell or being affected by it.</p>
             <p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 6th level or higher, you can target one additional creature for each slot level above 5th. All targets must be within 30 feet of each other.</p>
@@ -273,7 +273,7 @@
         </setters>
     </element>
     <element name="Tether Essence" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_TETHER_ESSENCE">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>Two creatures you can see within range must make a Constitution saving throw, with disadvantage if they are within 30 feet of each other. Either creature can willingly fail the save. If either save succeeds, the spell has no effect. If both saves fail, the creatures are magically linked for the duration, regardless of the distance between them. When damage is dealt to one of them, the same damage is dealt to the other one. If hit points are restored to one of them, the same number of hit points are restored to the other one. If either of the tethered creatures is reduced to 0 hit points, the spell ends on both. If the spell ends on one creature, it ends on both.</p>
         </description>
@@ -293,7 +293,7 @@
         </setters>
     </element>
     <element name="Time Ravage" type="Spell" source="Explorer’s Guide to Wildemount" id="ID_WOTC_EGTW_SPELL_TIME_RAVAGE">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You target a creature you can see within range, putting its physical form through the devastation of rapid aging. The target must make a Constitution saving throw, taking 10d12 points of necrotic damage on a failed save, or half as much damage on a successful one. If the save fails, the target also ages tot he point where it has only 30 days left before it dies of old age. In this aged state, the target has disadvantage on attack rolls, ability checks, and saving throws, and its walking speed is halved. Only the <em>wish</em> spell or the <em>greater restoration</em> spell cast with a 9th-level spell slot can end these effects and restore the target to its previous age.</p>
         </description>

--- a/supplements/guildmasters-guide-to-ravnica/spells.xml
+++ b/supplements/guildmasters-guide-to-ravnica/spells.xml
@@ -4,7 +4,7 @@
         <name>Spells</name>
         <description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/guildmasters-guide-ravnica">Guildmasters’ Guide to Ravnica</author>
-        <update version="0.0.3">
+        <update version="0.0.4">
             <file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/guildmasters-guide-to-ravnica/spells.xml" />
         </update>
     </info>	
@@ -30,6 +30,7 @@
         </setters>
     </element>
 	<element name="Chaos Bolt" type="Spell" source="Guildmasters’ Guide to Ravnica" id="ID_GGTR_SPELL_CHAOS_BOLT">
+        <supports>Spell Attack</supports>
         <description>
             <p>You hurl an undulating, warbling mass of chaotic energy at one creature in range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 + 1d6 damage. Choose one of the d8s. The number rolled on that die determines the attack's damage type, as shown below.</p>
             <table>

--- a/supplements/guildmasters-guide-to-ravnica/spells.xml
+++ b/supplements/guildmasters-guide-to-ravnica/spells.xml
@@ -30,7 +30,7 @@
         </setters>
     </element>
 	<element name="Chaos Bolt" type="Spell" source="Guildmasters’ Guide to Ravnica" id="ID_GGTR_SPELL_CHAOS_BOLT">
-        <supports>Spell Attack</supports>
+        <supports>Ranged, Spell Attack</supports>
         <description>
             <p>You hurl an undulating, warbling mass of chaotic energy at one creature in range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 + 1d6 damage. Choose one of the d8s. The number rolled on that die determines the attack's damage type, as shown below.</p>
             <table>

--- a/supplements/princes-of-the-apocalypse/spells.xml
+++ b/supplements/princes-of-the-apocalypse/spells.xml
@@ -4,13 +4,13 @@
 		<name>Spells</name>
 		<description>The spells from the Princes of the Apocalypse.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/princes-apocalypse">Wizards of the Coast</author>
-		<update version="0.1.5">
+		<update version="0.1.6">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/princes-of-the-apocalypse/spells.xml" />
 		</update>
 	</info>
 
 	<element name="Abi-Dalzim’s Horrid Wilting" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_ABIDALZIMSHORRIDWILTING">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You draw the moisture from every creature in a 30-foot cube centered on a point you choose within range. Each creature in that area must make a Constitution saving throw. Constructs and undead aren’t affected, and plants and water elementals make this saving throw with disadvantage. A creature takes 12d8 necrotic damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent">Nonmagical plants in the area that aren’t creatures, such as trees and shrubs, wither and die instantly.</p>
@@ -52,7 +52,7 @@
 		</setters>
 	</element>
 	<element name="Aganazzar’s Scorcher" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_AGANAZZARSSCORCHER">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A line of roaring flame 30 feet long and 5 feet wide emanates from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one.</p>
 			<p>
@@ -93,7 +93,7 @@
 		</setters>
 	</element>
 	<element name="Bones of the Earth" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_BONESOFTHEEARTH">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius. The rubble lasts until cleared. Each 5-foot-diameter portion of the area requires at least 1 minute to clear by hand.</p>
 			<p class="indent">If a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.</p>
@@ -117,7 +117,7 @@
 		</setters>
 	</element>
 	<element name="Catapult" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_CATAPULT">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose one object weighing 1 to 5 pounds within range that isn’t being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. When the object strikes something, the object and what it strikes each take 3d8 bludgeoning damage.</p>
 			<p>
@@ -139,7 +139,7 @@
 		</setters>
 	</element>
 	<element name="Create Bonfire" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_CREATEBONFIRE">
-		<supports>Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a bonfire on ground that you can see within range. Until the spell ends, the magic bonfire fills a 5-foot cube. Any creature in the bonfire’s space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it moves into the bonfire’s space for the first time on a turn or ends its turn there.</p>
 			<p class="indent">The bonfire ignites flammable objects in its area that aren’t being worn or carried.</p>
@@ -186,7 +186,7 @@
 		</setters>
 	</element>
 	<element name="Control Winds" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_CONTROLWINDS">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You take control of the air in a 100-foot cube that you can see within range. Choose one of the following effects when you cast the spell. The effect lasts for the spell’s duration, unless you use your action on a later turn to switch to a different effect. You can also use your action to temporarily halt the effect or to restart one you’ve halted.</p>
 			<p class="indent">Gusts. A wind picks up within the cube, continually blowing in a horizontal direction that you choose. You choose the intensity of the wind: calm, moderate, or strong. If the wind is moderate or strong, ranged weapon attacks that enter or leave the cube or pass through it have disadvantage on their attack rolls. If the wind is strong, any creature moving against the wind must spend 1 extra foot of movement for each foot moved.</p>
@@ -208,7 +208,7 @@
 		</setters>
 	</element>
 	<element name="Dust Devil" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_DUSTDEVIL">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose an unoccupied 5-foot cube of air that you can see within range. An elemental force that resembles a dust devil appears in the cube and lasts for the spell’s duration.</p>
 			<p class="indent">Any creature that ends its turn within 5 feet of the dust devil must make a Strength saving throw. On a failed save, the creature takes 1d8 bludgeoning damage and is pushed 10 feet away from the dust devil. On a successful save, the creature takes half as much damage and isn’t pushed.</p>
@@ -232,7 +232,7 @@
 		</setters>
 	</element>
 	<element name="Earthbind" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_EARTHBIND">
-		<supports>Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose one creature you can see within range. Yellow strips of magical energy loop around the creature. The target must succeed on a Strength saving throw or its flying speed (if any) is reduced to 0 feet for the spell’s duration. An airborne creature affected by this spell safely descends at 60 feet per round until it reaches the ground or the spell ends.</p>
 		</description>
@@ -251,7 +251,7 @@
 		</setters>
 	</element>
 	<element name="Earth Tremor" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_EARTHTREMOR">
-		<supports>Bard, Druid, Sorcerer, Wizard</supports>
+		<supports>Bard, Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You cause a tremor in the ground in a 10-foot radius. Each creature other than you in that area must make a Dexterity saving throw. On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone. If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared, with each 5-foot-diameter portion requiring at least 1 minute to clear by hand.</p>
 			<p>
@@ -273,7 +273,7 @@
 		</setters>
 	</element>
 	<element name="Elemental Bane" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_ELEMENTALBANE">
-		<supports>Druid, Warlock, Wizard</supports>
+		<supports>Druid, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose one creature you can see within range, and choose one of the following damage types: acid, cold, fire, lightning, or thunder. The target must succeed on a Constitution saving throw or be affected by the spell for its duration. The first time each turn the affected target takes damage of the chosen type, the target takes an extra 2d6 damage of that type. Moreover, the target loses any resistance to that damage type until the spell ends.</p>
 			<p>
@@ -295,7 +295,7 @@
 		</setters>
 	</element>
 	<element name="Erupting Earth" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_ERUPTINGEARTH">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared away. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.</p>
 			<p>
@@ -339,7 +339,7 @@
 		</setters>
 	</element>
 	<element name="Frostbite" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_FROSTBITE">
-		<supports>Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn.</p>
 			<p class="indent">The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -359,7 +359,7 @@
 		</setters>
 	</element>
 	<element name="Gust" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_GUST">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You seize the air and compel it to create one of the following effects at a point you can see within range:</p>
 			<ul>
@@ -383,7 +383,7 @@
 		</setters>
 	</element>
 	<element name="Ice Knife" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_ICEKNIFE">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of it must succeed on a Dexterity saving throw or take 2d6 cold damage.</p>
 			<p>
@@ -405,7 +405,7 @@
 		</setters>
 	</element>
 	<element name="Immolation" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_IMMOLATION">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 8d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell’s duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 4d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can’t be extinguished through nonmagical means.</p>
 			<p class="indent">If damage from this spell kills a target, the target is turned to ash.</p>
@@ -425,7 +425,7 @@
 		</setters>
 	</element>
 	<element name="Investiture of Flame" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_INVESTITUREOFFLAME">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell’s duration. The flames don’t harm you. Until the spell ends, you gain the following benefits:</p>
 			<ul>
@@ -449,7 +449,7 @@
 		</setters>
 	</element>
 	<element name="Investiture of Ice" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_INVESTITUREOFICE">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Until the spell ends, ice rimes your body, and you gain the following benefits:</p>
 			<ul>
@@ -474,7 +474,7 @@
 		</setters>
 	</element>
 	<element name="Investiture of Stone" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_INVESTITUREOFSTONE">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Until the spell ends, bits of rock spread across your body, and you gain the following benefits:</p>
 			<ul>
@@ -498,7 +498,7 @@
 		</setters>
 	</element>
 	<element name="Investiture of Wind" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_INVESTITUREOFWIND">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Until the spell ends, wind whirls around you, and you gain the following benefits:</p>
 			<ul>
@@ -522,7 +522,7 @@
 		</setters>
 	</element>
 	<element name="Maelstrom" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_MAELSTROM">
-		<supports>Druid</supports>
+		<supports>Druid, Spell Saving Throw</supports>
 		<description>
 			<p>A mass of 5-foot-deep water appears and swirls in a 30-foot radius centered on a point you can see within range. The point must be on ground or in a body of water. Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.</p>
 		</description>
@@ -541,7 +541,7 @@
 		</setters>
 	</element>
 	<element name="Magic Stone" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_MAGICSTONE">
-		<supports>Druid, Warlock</supports>
+		<supports>Druid, Warlock, Spell Attack</supports>
 		<description>
 			<p>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker’s, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</p>
 			<p class="indent">If you cast this spell again, the spell ends on any pebbles still affected by your previous casting.</p>
@@ -561,7 +561,7 @@
 		</setters>
 	</element>
 	<element name="Maximilian’s Earthen Grasp" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_MAXIMILIANSEARTHENGRASP">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell’s duration.</p>
 			<p class="indent">As an action, you can cause the hand to crush the restrained target, who must make a Strength saving throw. It takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.</p>
@@ -583,7 +583,7 @@
 		</setters>
 	</element>
 	<element name="Melf’s Minute Meteors" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_MELFSMINUTEMETEORS">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create six tiny meteors in your space. They float in the air and orbit you for the spell’s duration. When you cast the spell—and as a bonus action on each of your turns thereafter—you can expend one or two of the meteors, sending them streaking toward a point or points you choose within 120 feet of you. Once a meteor reaches its destination or impacts against a solid surface, the meteor explodes. Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one.</p>
 			<p>
@@ -650,7 +650,7 @@
 		</setters>
 	</element>
 	<element name="Pyrotechnics" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_PYROTECHNICS">
-		<supports>Bard, Sorcerer, Wizard</supports>
+		<supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Choose an area of nonmagical flame that you can see and that fits within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke.</p>
 			<p class="indent">Fireworks. The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.</p>
@@ -716,7 +716,7 @@
 		</setters>
 	</element>
 	<element name="Snilloc’s Snowball Swarm" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_SNILLOCSSNOWBALLSWARM">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A flurry of magic snowballs erupts from a point you choose within range. Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one.</p>
 			<p>
@@ -738,7 +738,7 @@
 		</setters>
 	</element>
 	<element name="Storm Sphere" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_STORMSPHERE">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell’s duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere’s space is difficult terrain.</p>
 			<p class="indent">Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</p>
@@ -762,7 +762,7 @@
 		</setters>
 	</element>
 	<element name="Thunderclap" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_THUNDERCLAP">
-		<supports>Bard, Druid, Sorcerer, Warlock, Wizard</supports>
+		<supports>Bard, Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a burst of thunderous sound, which can be heard 100 feet away. Each creature within range, other than you, must succeed on a Constitution saving throw or take 1d6 thunder damage.</p>
 			<p class="indent">The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -782,7 +782,7 @@
 		</setters>
 	</element>
 	<element name="Tidal Wave" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_TIDALWAVE">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You conjure up a wave of water that crashes down on an area within range. The area can be up to 30 feet long, up to 10 feet wide, and up to 10 feet tall. Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a success, a creature takes half as much damage and isn’t knocked prone. The water then spreads out across the ground in all directions, extinguishing unprotected flames in its area and within 30 feet of it, and then it vanishes</p>
 		</description>
@@ -801,7 +801,7 @@
 		</setters>
 	</element>
 	<element name="Transmute Rock" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_TRANSMUTEROCK">
-		<supports>Druid, Wizard</supports>
+		<supports>Druid, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You choose an area of stone or mud that you can see that fits within a 40-foot cube and that is within range, and choose one of the following effects.</p>
 			<p class="indent">Transmute Rock to Mud. Nonmagical rock of any sort in the area becomes an equal volume of thick and flowing mud that remains for the spell’s duration.</p>
@@ -824,7 +824,7 @@
 		</setters>
 	</element>
 	<element name="Vitriolic Sphere" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_VITRIOLICSPHERE">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You point at a location within range, and a glowing, 1-foot-diameter ball of emerald acid streaks there and explodes in a 20-foot-radius sphere. Each creature in that area must make a Dexterity saving throw. On a failed save, a creature takes 10d4 acid damage and another 5d4 acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage and no damage at the end of its next turn.</p>
 			<p>
@@ -912,7 +912,7 @@
 		</setters>
 	</element>
 	<element name="Watery Sphere" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_WATERYSPHERE">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You conjure up a sphere of water with a 5-foot radius on a point you can see within range. The sphere can hover in the air, but no more than 10 feet off the ground. The sphere remains for the spell’s duration.</p>
 			<p class="indent">Any creature in the sphere’s space must make a Strength saving throw. On a successful save, a creature is ejected from that space to the nearest unoccupied space of the creature’s choice outside the sphere. A Huge or larger creature succeeds on the saving throw automatically, and a Large or smaller creature can choose to fail it. On a failed save, a creature is restrained by the sphere and is engulfed by the water. At the end of each of its turns, a restrained target can repeat the saving throw, ending the effect on itself on a success.</p>
@@ -935,7 +935,7 @@
 		</setters>
 	</element>
 	<element name="Whirlwind" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_WHIRLWIND">
-		<supports>Druid, Sorcerer, Wizard</supports>
+		<supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 		<p>A whirlwind howls down to a point that you can see on the ground within range. The whirlwind is a 10-foot-radius, 30-foot-high cylinder centered on that point. Until the spell ends, you can use your action to move the whirlwind up to 30 feet in any direction along the ground. The whirlwind sucks up any Medium or smaller objects that aren't secured to anything and that aren't worn or carried by anyone.</p>
 		<p class="indent">A creature must make a Dexterity saving throw the first time on a turn that it enters the whirlwind or that the whirlwind enters its space, including when the whirlwind first appears. A creature takes 10d6 bludgeoning damage on a failed save, or half as much damage on a successful one. In addition, a Large or smaller creature that fails the save must succeed on a Strength saving throw or become restrained in the whirlwind until the spell ends. When a creature starts its turn restrained by the whirlwind, the creature is pulled 5 feet higher inside it, unless the creature is at the top. A restrained creature moves with the whirlwind and falls when the spell ends, unless the creature has some means to stay aloft.</p>

--- a/supplements/princes-of-the-apocalypse/spells.xml
+++ b/supplements/princes-of-the-apocalypse/spells.xml
@@ -383,7 +383,7 @@
 		</setters>
 	</element>
 	<element name="Ice Knife" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_ICEKNIFE">
-		<supports>Druid, Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
+		<supports>Druid, Sorcerer, Wizard, Ranged, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of it must succeed on a Dexterity saving throw or take 2d6 cold damage.</p>
 			<p>
@@ -541,7 +541,7 @@
 		</setters>
 	</element>
 	<element name="Magic Stone" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_MAGICSTONE">
-		<supports>Druid, Warlock, Spell Attack</supports>
+		<supports>Druid, Warlock, Ranged, Spell Attack</supports>
 		<description>
 			<p>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker’s, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</p>
 			<p class="indent">If you cast this spell again, the spell ends on any pebbles still affected by your previous casting.</p>
@@ -738,7 +738,7 @@
 		</setters>
 	</element>
 	<element name="Storm Sphere" type="Spell" source="Princes of the Apocalypse" id="ID_POTA_SPELL_STORMSPHERE">
-		<supports>Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
+		<supports>Sorcerer, Wizard, Ranged, Spell Attack, Spell Saving Throw</supports>
 		<description>
 			<p>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell’s duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere’s space is difficult terrain.</p>
 			<p class="indent">Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</p>

--- a/supplements/rime-of-the-frostmaiden/spells.xml
+++ b/supplements/rime-of-the-frostmaiden/spells.xml
@@ -6,7 +6,7 @@
 		</update>
 	</info>	
 	<element name="Blade of Disaster" type="Spell" source="Icewind Dale: Rime of the Frostmaiden" id="ID_WOTC_IDROTF_SPELL_BLADE_OF_DISASTER">
-		<supports>Wizard, Spell Attack</supports>
+		<supports>Wizard, Melee, Spell Attack</supports>
 		<description>
 			<p>You create a blade-shaped planar rift about 3 feet long in an unoccupied space you can see within range. The blade lasts for the duration. When you cast this spell, you can make up to two melee spell attacks with the blade, each one against a creature, loose object, or structure within 5 feet of the blade. On a hit, the target takes 4d12 force damage. This attack scores a critical hit if the number on the d20 is 18 or higher. On a critical hit, the blade deals an extra 8d12 force damage (for a total of 12d12 force damage).</p>
 			<p class="indent">As a bonus action on your turn, you can move the blade up to 30 feet to an unoccupied space you can see and then make up to two melee spell attacks with it again.</p>

--- a/supplements/rime-of-the-frostmaiden/spells.xml
+++ b/supplements/rime-of-the-frostmaiden/spells.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.1">
+		<update version="0.1.1">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/rime-of-the-frostmaiden/spells.xml" />
 		</update>
 	</info>	
 	<element name="Blade of Disaster" type="Spell" source="Icewind Dale: Rime of the Frostmaiden" id="ID_WOTC_IDROTF_SPELL_BLADE_OF_DISASTER">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Attack</supports>
 		<description>
 			<p>You create a blade-shaped planar rift about 3 feet long in an unoccupied space you can see within range. The blade lasts for the duration. When you cast this spell, you can make up to two melee spell attacks with the blade, each one against a creature, loose object, or structure within 5 feet of the blade. On a hit, the target takes 4d12 force damage. This attack scores a critical hit if the number on the d20 is 18 or higher. On a critical hit, the blade deals an extra 8d12 force damage (for a total of 12d12 force damage).</p>
 			<p class="indent">As a bonus action on your turn, you can move the blade up to 30 feet to an unoccupied space you can see and then make up to two melee spell attacks with it again.</p>
@@ -50,7 +50,7 @@
 		</setters>
 	</element>
 	<element name="Frost Fingers" type="Spell" source="Icewind Dale: Rime of the Frostmaiden" id="ID_WOTC_IDROTF_SPELL_FROST_FINGERS">
-		<supports>Wizard</supports>
+		<supports>Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>Freezing cold blasts from your fingertips in a 15-foot cone. Each creature in that area must make a Constitution saving throw, taking 2d8 cold damage on a failed save, or half as much damage on a successful one.</p>
 			<p class="indent">The cold freezes nonmagical liquids in the area that aren't being worn or carried.</p>

--- a/supplements/sword-coast-adventurers-guide/spells.xml
+++ b/supplements/sword-coast-adventurers-guide/spells.xml
@@ -4,7 +4,7 @@
 		<name>Spells</name>
 		<description>The spells from the Sword Coast Adventurer’s Guide.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/sc-adventurers-guide">Wizards of the Coast</author>
-		<update version="0.2.2">
+		<update version="0.2.3">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/sword-coast-adventurers-guide/spells.xml" />
 		</update>
 	</info>
@@ -52,7 +52,7 @@
 		</setters>
 	</element>
 	<element name="Lightning Lure" type="Spell" source="Sword Coast Adventurer’s Guide" id="ID_SCAG_SPELL_LIGHTNING_LURE">
-		<supports>Sorcerer, Wizard, Warlock</supports>
+		<supports>Sorcerer, Wizard, Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>You create a lash of lightning energy that strikes at one creature of your choice that you can see within 15 feet of you. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.</p>
 			<p class="indent">This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
@@ -73,7 +73,7 @@
 		</setters>
 	</element>
 	<element name="Sword Burst" type="Spell" source="Sword Coast Adventurer’s Guide" id="ID_SCAG_SPELL_SWORD_BURST">
-		<supports>Sorcerer, Wizard, Warlock</supports>
+		<supports>Sorcerer, Wizard, Warlock, Spell Saving Throw</supports>
 		<description>
 			<p>You create a momentary circle of spectral blades that sweep around you. All other creatures within 5 feet of you must succeed on a Dexterity saving throw or take 1d6 force damage.</p>
 			<p class="indent">This spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>

--- a/supplements/tashas-cauldron-of-everything/spells.xml
+++ b/supplements/tashas-cauldron-of-everything/spells.xml
@@ -4,12 +4,12 @@
 		<name>Spells</name>
 		<description>The Spells Arcane Tradition from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/spells.xml" />
 		</update>
 	</info>
 	<element name="Blade Of Disaster" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_BLADE_OF_DISASTER">
-		<supports>Sorcerer, Warlock, Wizard</supports>
+		<supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
 		<description>
 			<p>You create a blade-shaped planar rift about 3 feet long in an unoccupied space you can see within range. The blade lasts for the duration.</p>
 			<p class="indent">When you cast this spell, you can make up to two melee spell attacks with the blade, each one against a creature, loose object, or structure within 5 feet of the blade. On a hit, the target takes 4d12 force damage. This attack scores a critical hit if the number on the d20 is 18 or higher. On a critical hit, the blade deals an extra 8d12 force damage (for a total of 12d12 force damage).</p>
@@ -102,7 +102,7 @@
 		</setters>
 	</element>
 	<element name="Lightning Lure" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_LIGHTNING_LURE">
-		<supports>Artificer, Sorcerer, Warlock, Wizard</supports>
+		<supports>Artificer, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a lash of lightning energy that strikes at one creature of your choice that you can see within 15 feet of you. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you. This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).</p>
 		</description>
@@ -118,7 +118,7 @@
 		</setters>
 	</element>
 	<element name="Mind Sliver" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_MIND_SLIVER">
-		<supports>Sorcerer, Warlock, Wizard</supports>
+		<supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You drive a disorienting spike of psychic energy into the mind of one creature you can see within range. The target must succeed on an Intelligence saving throw or take 1d6 psychic damage and subtract 1d4 from the next saving throw it makes before the end of your next turn.</p>
 			<p class="indent">This spell’s damage increases by 1d6 when you reach certain levels: 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -363,7 +363,7 @@
 		</setters>
 	</element>
 	<element name="Sword Burst" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_SWORD_BURST">
-		<supports>Artificer, Sorcerer, Warlock, Wizard</supports>
+		<supports>Artificer, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You create a momentary circle of spectral blades that sweep around you. All other creatures within 5 feet of you must succeed on a Dexterity saving throw or take 1d6 force damage This spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
 		</description>
@@ -379,7 +379,7 @@
 		</setters>
 	</element>
 	<element name="Tasha’s Caustic Brew" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_TASHAS_CAUSTIC_BREW">
-		<supports>Artificer, Sorcerer, Wizard</supports>
+		<supports>Artificer, Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>A stream of acid emanates from you in a line 30 feet long and 5 feet wide in a direction you choose. Each creature in the line must succeed on a Dexterity saving throw or be covered in acid for the spell’s duration or until a creature uses its action to scrape or wash the acid off itself or another creature. A creature covered in the acid takes 2d4 acid damage at start of each of its turns.</p>
 		</description>
@@ -397,7 +397,7 @@
 		</setters>
 	</element>
 	<element name="Tasha’s Mind Whip" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_TASHAS_MIND_WHIP">
-		<supports>Sorcerer, Wizard</supports>
+		<supports>Sorcerer, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>You psychically lash out at one creature you can see within range. The target must make an Intelligence saving throw. On a failed save, the target takes 3d6 psychic damage, and it can’t take a reaction until the end of its next turn. Moreover, on its next turn, it must choose whether it gets a move, an action, or a bonus action; it gets only one of the three. On a successful save, the target takes half as much damage and suffers none of the spell’s other effects.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 3rd level or higher, you can target one additional creature for each slot level above 2nd. The creatures must be within 30 feet of each other when you target them.</p>

--- a/supplements/tashas-cauldron-of-everything/spells.xml
+++ b/supplements/tashas-cauldron-of-everything/spells.xml
@@ -9,7 +9,7 @@
 		</update>
 	</info>
 	<element name="Blade Of Disaster" type="Spell" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_SPELL_BLADE_OF_DISASTER">
-		<supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
+		<supports>Sorcerer, Warlock, Wizard, Melee, Spell Attack</supports>
 		<description>
 			<p>You create a blade-shaped planar rift about 3 feet long in an unoccupied space you can see within range. The blade lasts for the duration.</p>
 			<p class="indent">When you cast this spell, you can make up to two melee spell attacks with the blade, each one against a creature, loose object, or structure within 5 feet of the blade. On a hit, the target takes 4d12 force damage. This attack scores a critical hit if the number on the d20 is 18 or higher. On a critical hit, the blade deals an extra 8d12 force damage (for a total of 12d12 force damage).</p>

--- a/supplements/tashas-cauldron-of-everything/spells.xml
+++ b/supplements/tashas-cauldron-of-everything/spells.xml
@@ -172,7 +172,7 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">a pickled tentacle and an eyeball in a platinum inlaid vial worth at least 100 gp</set>
+			<set name="materialComponent">a pickled tentacle and an eyeball in a platinum inlaid vial worth at least 400 gp</set>
 			<set name="duration">Concentration, up to 1 hour.</set>
 			<set name="isConcentration">true</set>
 		</setters>

--- a/supplements/xanathars-guide-to-everything/spells.xml
+++ b/supplements/xanathars-guide-to-everything/spells.xml
@@ -203,7 +203,7 @@
         </setters>
     </element>
     <element name="Chaos Bolt" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CHAOS_BOLT">
-        <supports>Sorcerer, Spell Attack</supports>
+        <supports>Sorcerer, Ranged, Spell Attack</supports>
         <description>
             <p>You hurl an undulating, warbling mass of chaotic energy at one creature in range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 + 1d6 damage. Choose one of the d8s. The number rolled on that die determines the attack’s damage type, as shown below.</p>
             <table>
@@ -353,7 +353,7 @@
         </setters>
     </element>
     <element name="Crown of Stars" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CROWN_OF_STARS">
-        <supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
+        <supports>Sorcerer, Warlock, Wizard, Ranged, Spell Attack</supports>
         <description>
             <p>Seven star-like motes of light appear and orbit your head until the spell ends. You can use a bonus action to send one of the motes streaking toward one creature or object within 120 feet of you. When you do so, make a ranged spell attack. On a hit, the target takes 4d12 radiant damage. Whether you hit or miss, the mote is expended. The spell ends early if you expend the last mote.</p>
             <p class="indent">If you have four or more motes remaining, they shed bright light in a 30-foot radius and dim light for an additional 30 feet. If you have one to three motes remaining, they shed dim light in a 30-foot radius.</p>
@@ -811,7 +811,7 @@
         </setters>
     </element>
     <element name="Ice Knife" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ICE_KNIFE">
-        <supports>Druid, Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
+        <supports>Druid, Sorcerer, Wizard, Ranged, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of it must succeed on a Dexterity saving throw or take 2d6 cold damage.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 2nd level or higher, the cold damage increases by 1d6 for each slot level above 1st.</p>
@@ -1105,7 +1105,7 @@
         </setters>
     </element>
     <element name="Magic Stone" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MAGIC_STONE">
-        <supports>Druid, Warlock, Artificer, Spell Attack</supports>
+        <supports>Druid, Warlock, Artificer, Ranged, Spell Attack</supports>
         <description>
             <p>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker’s, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</p>
             <p class="indent">If you cast this spell again, the spell ends early on any pebbles still affected by it.</p>
@@ -1330,7 +1330,7 @@
         </setters>
     </element>
     <element name="Primal Savagery" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_PRIMAL_SAVAGERY">
-        <supports>Druid, Spell Attack</supports>
+        <supports>Druid, Melee, Spell Attack</supports>
         <description>
             <p>You channel primal magic to cause your teeth or fingernails to sharpen, ready to deliver a corrosive attack. Make a melee spell attack against one creature within 5 feet of you. On a hit, the target takes 1d10 acid damage. After you make the attack, your teeth or fingernails return to normal.</p>
             <p class="indent">The spell’s damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</p>
@@ -1638,7 +1638,7 @@
         </setters>
     </element>
     <element name="Steel Wind Strike" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_STEEL_WIND_STRIKE">
-        <supports>Ranger, Wizard, Spell Attack</supports>
+        <supports>Ranger, Wizard, Melee, Spell Attack</supports>
         <description>
             <p>You flourish the weapon used in the casting and then vanish to strike like the wind. Choose up to five creatures you can see within range. Make a melee spell attack against each target. On a hit, a target takes 6d10 force damage.</p>
             <p class="indent">You can then teleport to an unoccupied space you can see within 5 feet of one of the targets you hit or missed.</p>
@@ -1659,7 +1659,7 @@
         </setters>
     </element>
     <element name="Storm Sphere" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_STORM_SPHERE">
-        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Attack, Spell Saving Throw</supports>
+        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Ranged, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell’s duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere’s space is difficult terrain.</p>
             <p class="indent">Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</p>
@@ -1962,7 +1962,7 @@
         </setters>
     </element>
     <element name="Wall of Light" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WALL_OF_LIGHT">
-        <supports>Sorcerer, Warlock, Wizard, Spell Attack, Spell Saving Throw</supports>
+        <supports>Sorcerer, Warlock, Wizard, Ranged, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>A shimmering wall of bright light appears at a point you choose within range. The wall appears in any orientation you choose: horizontally, vertically, or diagonally. It can be free floating, or it can rest on a solid surface. The wall can be up to 60 feet long, 10 feet high, and 5 feet thick. The wall blocks line of sight, but creatures and objects can pass through it. It emits bright light out to 120 feet and dim light for an additional 120 feet.</p>
             <p class="indent">When the wall appears, each creature in its area must make a Constitution saving throw. On a failed save, a creature takes 4d8 radiant damage, and it is blinded for 1 minute. On a successful save, it takes half as much damage and isn’t blinded. A blinded creature can make a Constitution saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
@@ -2122,7 +2122,7 @@
         </setters>
     </element>
     <element name="Wrath of Nature" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WRATH_OF_NATURE">
-        <supports>Druid, Ranger, Spell Attack, Spell Saving Throw</supports>
+        <supports>Druid, Ranger, Ranged, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>You call out to the spirits of nature to rouse them against your enemies. Choose a point you can see within range. The spirits cause trees, rocks, and grasses in a 60-foot cube centered on that point to become animated until the spell ends.</p>
             <p class="indent">Grasses and Undergrowth. Any area of ground in the cube that is covered by grass or undergrowth is difficult terrain for your enemies.</p>

--- a/supplements/xanathars-guide-to-everything/spells.xml
+++ b/supplements/xanathars-guide-to-everything/spells.xml
@@ -2,13 +2,13 @@
 <elements>
     <info>
         <name>Spells</name>
-        <update version="0.1.6">
+        <update version="0.1.7">
             <file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/xanathars-guide-to-everything/spells.xml" />
         </update>
     </info>
 
     <element name="Abi-Dalzim’s Horrid Wilting" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ABI_DALZIMS_HORRID_WILTING">
-        <supports>Sorcerer, Wizard</supports>
+        <supports>Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You draw the moisture from every creature in a 30-foot cube centered on a point you choose within range. Each creature in that area must make a Constitution saving throw. Constructs and undead aren’t affected, and plants and water elementals make this saving throw with disadvantage. A creature takes 12d8 necrotic damage on a failed save, or half as much damage on a successful one.</p>
             <p class="indent">Nonmagical plants in the area that aren’t creatures, such as trees and shrubs, wither and die instantly.</p>
@@ -50,7 +50,7 @@
         </setters>
     </element>
     <element name="Aganazzar’s Scorcher" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_AGANAZZARS_SCORCHER">
-        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight)</supports>
+        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>A line of roaring flame 30 feet long and 5 feet wide emanates from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes 3d8 fire damage on a failed save, or half as much damage on a successful one.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</p>
@@ -91,7 +91,7 @@
         </setters>
     </element>
     <element name="Bones of the Earth" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_BONES_OF_THE_EARTH">
-        <supports>Druid</supports>
+        <supports>Druid, Spell Saving Throw</supports>
         <description>
             <p>You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius that lasts until cleared. Each 5-foot-diameter portion of the area requires at least 1 minutes to clear by hand.</p>
             <p class="indent">If a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.</p>
@@ -114,7 +114,7 @@
         </setters>
     </element>
     <element name="Catapult" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CATAPULT">
-        <supports>Sorcerer, Wizard, Artificer</supports>
+        <supports>Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
         <description>
             <p>Choose one object weighing 1 to 5 pounds within range that isn’t being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. When the object strikes something, the object and what it strikes each take 3d8 bludgeoning damage.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 2nd level or higher, the maximum weight of objects that you can target with this spell increases by 5 pounds, and the damage increases by 1d8, for each slot level above 1st.</p>
@@ -156,7 +156,7 @@
         </setters>
     </element>
     <element name="Cause Fear" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CAUSE_FEAR">
-        <supports>Warlock, Wizard</supports>
+        <supports>Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You awaken the sense of mortality in one creature you can see within range. A construct or an undead is immune to this effect. The target must succeed on a Wisdom saving throw or become frightened of you until the spell ends. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st. The creatures must be within 30 feet of each other when you target them.</p>
@@ -203,7 +203,7 @@
         </setters>
     </element>
     <element name="Chaos Bolt" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CHAOS_BOLT">
-        <supports>Sorcerer</supports>
+        <supports>Sorcerer, Spell Attack</supports>
         <description>
             <p>You hurl an undulating, warbling mass of chaotic energy at one creature in range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 + 1d6 damage. Choose one of the d8s. The number rolled on that die determines the attack’s damage type, as shown below.</p>
             <table>
@@ -238,7 +238,7 @@
         </setters>
     </element>
     <element name="Charm Monster" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CHARM_MONSTER">
-        <supports>Bard, Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Bard, Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You attempt to charm a creature you can see within range. It must make a Wisdom saving throw, and it does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it. The charmed creature is friendly to you. When the spell ends, the creature knows it was charmed by you.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.</p>
@@ -286,7 +286,7 @@
         </setters>
     </element>
     <element name="Control Winds" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CONTROL_WINDS">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You take control of the air in a 100-foot cube that you can see within range. Choose one of the following effects when you cast the spell. The effect lasts for the spell’s duration, unless you use your action on a later turn to switch to a different effect. You can also use your action to temporarily halt the effect or to restart one you’ve halted.</p>
             <p class="indent"><b><i>Gusts. </i></b>A wind picks up within the cube, continually blowing in a horizontal direction you designate. You choose the intensity of the wind: calm, moderate, or strong. If the wind is moderate or strong, ranged weapon attacks that enter or leave the cube or pass through it have disadvantage on their attack rolls. If the wind is strong, any creature moving against the wind must spend 1 extra foot of movement for each foot moved.</p>
@@ -309,7 +309,7 @@
         </setters>
     </element>
     <element name="Create Bonfire" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CREATE_BONFIRE">
-        <supports>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight), Artificer</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight), Artificer, Spell Saving Throw</supports>
         <description>
             <p>You create a bonfire on ground that you can see within range. Until the spells ends, the bonfire fills a 5-foot cube. Any creature in the bonfire’s space when you cast the spell must succeed on a Dexterity saving throw or take 1d8 fire damage. A creature must also make the saving throw when it enters the bonfire’s space for the first time on a turn or ends its turn there.</p>
             <p class="indent">The bonfire ignites flammable objects in its area that aren’t being worn or carried.</p>
@@ -353,7 +353,7 @@
         </setters>
     </element>
     <element name="Crown of Stars" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_CROWN_OF_STARS">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Attack</supports>
         <description>
             <p>Seven star-like motes of light appear and orbit your head until the spell ends. You can use a bonus action to send one of the motes streaking toward one creature or object within 120 feet of you. When you do so, make a ranged spell attack. On a hit, the target takes 4d12 radiant damage. Whether you hit or miss, the mote is expended. The spell ends early if you expend the last mote.</p>
             <p class="indent">If you have four or more motes remaining, they shed bright light in a 30-foot radius and dim light for an additional 30 feet. If you have one to three motes remaining, they shed dim light in a 30-foot radius.</p>
@@ -398,7 +398,7 @@
         </setters>
     </element>
     <element name="Dawn" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_DAWN">
-        <supports>Cleric, Wizard</supports>
+        <supports>Cleric, Wizard, Spell Saving Throw</supports>
         <description>
             <p>The light of dawn shines down on a location you specify within range. Until the spell ends, a 30-foot-radius, 40-foot-high cylinder of bright light glimmers there. This light is sunlight.</p>
             <p class="indent">When the cylinder appears, each creature in it must make a Constitution saving throw, taking 4d10 radiant damage on a failed save, or half as much damage on a successful one. A creature must also make this saving throw whenever it ends its turn in the cylinder.</p>
@@ -420,7 +420,7 @@
         </setters>
     </element>
     <element name="Dragon’s Breath" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_DRAGONS_BREATH">
-        <supports>Sorcerer, Wizard</supports>
+        <supports>Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You touch one willing creature and imbue it with the power to spew magical energy from its mouth, provided it has one. Choose acid, cold, fire, lightning, or poison. Until the spell ends, the creature can use an action to exhale energy of the chosen type in a 15-foot cone. Each creature in that area must make a Dexterity saving throw, taking 3d6 damage of the chosen type on a failed save, or half as much damage on a successful one.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</p>
@@ -473,7 +473,7 @@
         </setters>
     </element>
     <element name="Dust Devil" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_DUST_DEVIL">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Choose an unoccupied 5-foot cube of air that you can see within range. An elemental force that resembles a dust devil appears in the cube and lasts for the spell’s duration.</p>
             <p class="indent">Any creature that ends its turn within 5 feet of the dust devil must make a Strength saving throw. On a failed save, the creature takes 1d8 bludgeoning damage and is pushed 10 feet away. On a successful save, the creature takes half as much damage and isn’t pushed.</p>
@@ -496,7 +496,7 @@
         </setters>
     </element>
     <element name="Earth Tremor" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_EARTH_TREMOR">
-        <supports>Bard, Druid, Sorcerer, Wizard, Fighter (Eldritch Knight)</supports>
+        <supports>Bard, Druid, Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>You cause a tremor in the ground within range. Each creature other than you in that area must make a Dexterity saving throw. On a failed save, a creature takes 1d6 bludgeoning damage and is knocked prone. If the ground in that area is loose earth or stone, it becomes difficult terrain until cleared, with each 5-foot-diameter portion requiring at least 1 minute to clear by hand.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.</p>
@@ -517,7 +517,7 @@
         </setters>
     </element>
     <element name="Earthbind" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_EARTHBIND">
-        <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Choose one creature you can see within range. Yellow strips of magical energy loop around the creature. The target must succeed on a Strength saving throw or its flying speed (if any) is reduced to 0 feet for the spell’s duration. An airborne creature affected by this spell descends at 60 feet per round until it reaches the ground or the spell ends.</p>
         </description>
@@ -537,7 +537,7 @@
         </setters>
     </element>
     <element name="Elemental Bane" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ELEMENTAL_BANE">
-        <supports>Druid, Warlock, Wizard, Artificer</supports>
+        <supports>Druid, Warlock, Wizard, Artificer, Spell Saving Throw</supports>
         <description>
             <p>Choose one creature you can see within range, and choose one of the following damage types: acid, cold, fire, lightning, or thunder. The target must succeed on a Constitution saving throw or be affected by the spell for its duration. The first time each turn the affected target takes damage of the chosen type, the target takes an extra 2d6 damage of that type. Moreover, the target loses any resistance to that damage type until the spell ends.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.</p>
@@ -558,7 +558,7 @@
         </setters>
     </element>
     <element name="Enemies Abound" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ENEMIES_ABOUND">
-        <supports>Bard, Sorcerer, Warlock, Wizard</supports>
+        <supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You reach into the mind of one creature you can see and force it to make an Intelligence saving throw. A creature automatically succeeds if it is immune to being frightened. On a failed save, the target loses the ability to distinguish friend from foe, regarding all creatures it can see as enemies until the spell ends. Each time the target takes damage, it can repeat the saving throw, ending the effect on itself on a success.</p>
             <p class="indent">Whenever the affected creature chooses another creature as a target, it must choose the target at random from among the creatures it can see within range of the attack, spell, or other ability it’s using. If an enemy provokes an opportunity attack from the affected creature, the creature must make that attack if it is able to.</p>
@@ -579,7 +579,7 @@
         </setters>
     </element>
     <element name="Enervation" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ENERVATION">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>A tendril of inky darkness reaches out from you, touching a creature you can see within range to drain life from it. The target must make a Dexterity saving throw. On a successful save, the target takes 2d8 necrotic damage, and the spell ends. On a failed save, the target takes 4d8 necrotic damage, and until the spell ends, you can use your action on each of your turns to automatically deal 4d8 necrotic damage to the target. The spell ends if you use your action to do anything else, if the target is ever outside the spell’s range, or if the target has total cover from you.</p>
             <p class="indent">Whenever the spell deals damage to a target, you regain hit points equal to half the amount of necrotic damage the target takes.</p>
@@ -601,7 +601,7 @@
         </setters>
     </element>
     <element name="Erupting Earth" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ERUPTING_EARTH">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared away. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d12 for each slot level above 3rd.</p>
@@ -687,7 +687,7 @@
         </setters>
     </element>
     <element name="Frostbite" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_FROSTBITE">
-        <supports>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>You cause numbing frost to form on one creature that you can see within range. The target must make a Constitution saving throw. On a failed save, the target takes 1d6 cold damage, and it has disadvantage on the next weapon attack roll it makes before the end of its next turn.</p>
             <p class="indent">The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -742,7 +742,7 @@
         </setters>
     </element>
     <element name="Gust" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_GUST">
-        <supports>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight)</supports>
+        <supports>Druid, Sorcerer, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>You seize the air and compel it to create one of the following effects at a point you can see within range.</p>
             <ul>
@@ -790,7 +790,7 @@
         </setters>
     </element>
     <element name="Holy Weapon" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_HOLY_WEAPON">
-        <supports>Cleric, Paladin</supports>
+        <supports>Cleric, Paladin, Spell Saving Throw</supports>
         <description>
             <p>You imbue a weapon you touch with holy power. Until the spell ends, the weapon emits bright light in a 30-foot radius and dim light for an additional 30 feet. In addition, weapon attacks made with it deal an extra 2d8 radiant damage on a hit. If the weapon isn’t already a magic weapon, it becomes one for the duration.</p>
             <p class="indent">As a bonus action on your turn, you can dismiss this spell and cause the weapon to emit a burst of radiance. Each creature of your choice that you can see within 30 feet of the weapon must make a Constitution saving throw. On a failed save, a creature takes 4d8 radiant damage, and it is blinded for 1 minute. On a successful save, a creature takes half as much damage and isn’t blinded. At the end of each of its turns, a blinded creature can make a Constitution saving throw, ending the effect on itself on a success.</p>
@@ -811,7 +811,7 @@
         </setters>
     </element>
     <element name="Ice Knife" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ICE_KNIFE">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of it must succeed on a Dexterity saving throw or take 2d6 cold damage.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 2nd level or higher, the cold damage increases by 1d6 for each slot level above 1st.</p>
@@ -832,7 +832,7 @@
         </setters>
     </element>
     <element name="Illusory Dragon" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_ILLUSORY_DRAGON">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>By gathering threads of shadow material from the Shadowfell, you create a Huge shadowy dragon in an unoccupied space that you can see within range. The illusion lasts for the spell’s duration and occupies its space, as if it were a creature.</p>
             <p class="indent">When the illusion appears, any of your enemies that can see it must succeed on a Wisdom saving throw or become frightened of it for 1 minute. If a frightened creature ends its turn in a location where it doesn’t have line of sight to the illusion, it can repeat the saving throw, ending the effect on itself on a success.</p>
@@ -855,7 +855,7 @@
         </setters>
     </element>
     <element name="Immolation" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_IMMOLATION">
-        <supports>Sorcerer, Wizard</supports>
+        <supports>Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Flames wreathe one creature you can see within range. The target must make a Dexterity saving throw. It takes 8d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell’s duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 4d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can’t be extinguished through nonmagical means.</p>
             <p class="indent">If damage from this spell kills a target, the target is turned to ash.</p>
@@ -901,7 +901,7 @@
         </setters>
     </element>
     <element name="Infestation" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_INFESTATION">
-        <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You cause a cloud of mites, fleas, and other parasites to appear momentarily on one creature you can see within range. The target must succeed on a Constitution saving throw, or it takes 1d6 poison damage and moves 5 feet in a random direction if it can move and its speed is at least 5 feet. Roll a d4 for the direction: 1., north; 2, south; 3, east; or 4, west. This movement doesn’t provoke opportunity attacks, and if the direction rolled is blocked, the target doesn’t move.</p>
             <p class="indent">The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -922,7 +922,7 @@
         </setters>
     </element>
     <element name="Investiture of Flame" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_INVESTITURE_OF_FLAME">
-        <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell’s duration. The flames don’t harm you. Until the spell ends, you gain the following benefits:</p>
             <ul>
@@ -947,7 +947,7 @@
         </setters>
     </element>
     <element name="Investiture of Ice" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_INVESTITURE_OF_ICE">
-        <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Until the spell ends, ice rimes your body, and you gain the following benefits:</p>
             <ul>
@@ -973,7 +973,7 @@
         </setters>
     </element>
     <element name="Investiture of Stone" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_INVESTITURE_OF_STONE">
-        <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Until the spell ends, bits of rock spread across your body, and you gain the following benefits:</p>
             <ul>
@@ -998,7 +998,7 @@
         </setters>
     </element>
     <element name="Investiture of Wind" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_INVESTITURE_OF_WIND">
-        <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+        <supports>Druid, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Until the spell ends, wind whirls around you, and you gain the following benefits.</p>
             <ul>
@@ -1064,7 +1064,7 @@
         </setters>
     </element>
     <element name="Maddening Darkness" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MADDENING_DARKNESS">
-        <supports>Warlock, Wizard</supports>
+        <supports>Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Magical darkness spreads from a point you choose within range to fill a 60 foot radius sphere until the spell ends. The darkness spreads around corners. A creature with darkvision can’t see through this darkness. Non magical light, as well as light created by spells of 8th level or lower, can’t illuminate the area.</p>
             <p class="indent">Shrieks, gibbering, and mad laughter can be heard within the sphere. Whenever a creature starts its turn in the sphere, it must make a Wisdom saving throw, taking 8d8 psychic damage on a failed save, or half as much damage on a successful one.</p>
@@ -1085,7 +1085,7 @@
         </setters>
     </element>
     <element name="Maelstrom" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MAELSTROM">
-        <supports>Druid</supports>
+        <supports>Druid, Spell Saving Throw</supports>
         <description>
             <p>A mass of 5-foot-deep water appears and swirls in a 30-foot radius centered on a point you can see within range. The point must be on ground or in a body of water. Until the spell ends, that area is difficult terrain, and any creature that starts its turn there must succeed on a Strength saving throw or take 6d6 bludgeoning damage and be pulled 10 feet toward the center.</p>
         </description>
@@ -1105,7 +1105,7 @@
         </setters>
     </element>
     <element name="Magic Stone" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MAGIC_STONE">
-        <supports>Druid, Warlock, Artificer</supports>
+        <supports>Druid, Warlock, Artificer, Spell Attack</supports>
         <description>
             <p>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, it has a range of 60 feet. If someone else attacks with the pebble, that attacker adds your spellcasting ability modifier, not the attacker’s, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Hit or miss, the spell then ends on the stone.</p>
             <p class="indent">If you cast this spell again, the spell ends early on any pebbles still affected by it.</p>
@@ -1126,7 +1126,7 @@
         </setters>
     </element>
     <element name="Mass Polymorph" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MASS_POLYMORPH">
-        <supports>Bard, Sorcerer, Wizard</supports>
+        <supports>Bard, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You transform up to ten creatures of your choice that you can see within range. An unwilling target must succeed on a Wisdom saving throw to resist the transformation. An unwilling shapechanger automatically succeeds on the save.</p>
             <p class="indent">Each target assumes a beast form of your choice, and you can choose the same form or different ones for each target. The new form can be any beast you have seen whose challenge rating is equal to or less than the target’s (or half the target’s level, if the target doesn’t have a challenge rating). The target’s game statistics, including mental ability scores, are replaced by the statistics of the chosen beast, but the target retains its hit points, alignment, and personality.</p>
@@ -1150,7 +1150,7 @@
         </setters>
     </element>
     <element name="Maximilian’s Earthen Grasp" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MAXIMILIANS_EARTHEN_GRASP">
-        <supports>Sorcerer, Wizard</supports>
+        <supports>Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell’s duration.</p>
             <p class="indent">As an action, you can cause the hand to crush the restrained target, who must make a Strength saving throw. It takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.</p>
@@ -1173,7 +1173,7 @@
         </setters>
     </element>
     <element name="Melf’s Minute Meteors" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MELFS_MINUTE_METEORS">
-        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight)</supports>
+        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>You create six tiny meteors in your space. They float in the air and orbit you for the spell’s duration. When you cast the spell-and as a bonus action on each of your turns thereafter-you can expend one or two of the meteors, sending them streaking toward a point or points you choose within 120 feet of you. Once a meteor reaches its destination or impacts against a solid surface, the meteor explodes. Each creature within 5 feet of the point where the meteor explodes must make a Dexterity saving throw. A creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 4th level or higher, the number of meteors created increases by two for each slot level above 3rd.</p>
@@ -1194,7 +1194,7 @@
         </setters>
     </element>
     <element name="Mental Prison" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MENTAL_PRISON">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You attempt to bind a creature within an illusory cell that only it perceives. One creature you can see within range must make an Intelligence saving throw. The target succeeds automatically if it is immune to being charmed. On a successful save, the target takes 5d10 psychic damage, and the spell ends. On a failed save, the target takes 5d10 psychic damage, and you make the area immediately around the target’s space appear dangerous to it in some way. You might cause the target to perceive itself as being surrounded by fire, floating razors, or hideous maws filled with dripping teeth. Whatever form the illusion takes, the target can’t see or hear anything beyond it and is restrained for the spell’s duration. If the target is moved out of the illusion, makes a melee attack through it, or reaches any part of its body through it, the target takes 10d10 psychic damage, and the spell ends.</p>
         </description>
@@ -1240,7 +1240,7 @@
         </setters>
     </element>
     <element name="Mind Spike" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_MIND_SPIKE">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You reach into the mind of one creature you can see within range. The target must make a Wisdom saving throw, taking 3d8 psychic damage on a failed save, or half as much damage on a successful one. On a failed save, you also always know the target’s location until the spell ends, but only while the two of you are on the same plane of existence. While you have this knowledge, the target can’t become hidden from you, and if it’s invisible, it gains no benefit from that condition against you.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.</p>
@@ -1287,7 +1287,7 @@
         </setters>
     </element>
     <element name="Negative Energy Flood" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_NEGATIVE_ENERGY_FLOOD">
-        <supports>Warlock, Wizard</supports>
+        <supports>Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You send ribbons of negative energy at one creature you can see within range. Unless the target is undead, it must make a Constitution saving throw, taking 5d12 necrotic damage on a failed save, or half as much damage on a successful one. A target killed by this damage rises up as a zombie at the start of your next turn. The zombie pursues whatever creature it can see that is closest to it. Statistics for the zombie are in the Monster Manual.</p>
             <p class="indent">If you target an undead with this spell, the target doesn’t make a saving throw. Instead, roll 5d12. The target gains half the total as temporary hit points.</p>
@@ -1308,7 +1308,7 @@
         </setters>
     </element>
     <element name="Power Word Pain" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_POWER_WORD_PAIN">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You speak a word of power that causes waves of intense pain to assail one creature you can see within range. If the target has 100 hit points or fewer, it is subject to crippling pain. Otherwise, the spell has no effect on it. A target is also unaffected if it is immune to being charmed.</p>
             <p class="indent">While the target is affected by crippling pain, any speed it has can be no higher than 10 feet. The target also has disadvantage on attack rolls, ability checks, and saving throws, other than Constitution saving throws. Finally, if the target tries to cast a spell, it must first succeed on a Constitution saving throw, or the casting fails and the spell is wasted.</p>
@@ -1330,7 +1330,7 @@
         </setters>
     </element>
     <element name="Primal Savagery" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_PRIMAL_SAVAGERY">
-        <supports>Druid</supports>
+        <supports>Druid, Spell Attack</supports>
         <description>
             <p>You channel primal magic to cause your teeth or fingernails to sharpen, ready to deliver a corrosive attack. Make a melee spell attack against one creature within 5 feet of you. On a hit, the target takes 1d10 acid damage. After you make the attack, your teeth or fingernails return to normal.</p>
             <p class="indent">The spell’s damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</p>
@@ -1372,7 +1372,7 @@
         </setters>
     </element>
     <element name="Psychic Scream" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_PSYCHIC_SCREAM">
-        <supports>Bard, Sorcerer, Warlock, Wizard</supports>
+        <supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You unleash the power of your mind to blast the intellect of up to ten creatures of your choice that you can see within range. Creatures that have an Intelligence score of 2 or lower are unaffected.</p>
             <p class="indent">Each target must make an Intelligence saving throw. On a failed save, a target takes 14d6 psychic damage and is stunned. On a successful save, a target takes half as much damage and isn’t stunned. If a target is killed by this damage, its head explodes, assuming it has one.</p>
@@ -1394,7 +1394,7 @@
         </setters>
     </element>
     <element name="Pyrotechnics" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_PYROTECHNICS">
-        <supports>Bard, Sorcerer, Wizard, Artificer</supports>
+        <supports>Bard, Sorcerer, Wizard, Artificer, Spell Saving Throw</supports>
         <description>
             <p>Choose an area of nonmagical flame that you can see and that can fit within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke.</p>
             <p class="indent">Fireworks: The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.</p>
@@ -1416,7 +1416,7 @@
         </setters>
     </element>
     <element name="Scatter" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_SCATTER">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>The air quivers around up to five creatures of your choice that you can see within range. An unwilling creature must succeed on a Wisdom saving throw to resist this spell. You teleport each affected target to an unoccupied space that you can see within 120 feet of you. That space must be on the ground or on a floor.</p>
         </description>
@@ -1506,7 +1506,7 @@
         </setters>
     </element>
     <element name="Sickening Radiance" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_SICKENING_RADIANCE">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>Dim, greenish light spreads within a 30-foot-radius sphere centered on a point you choose within range. The light spreads around corners, and it lasts until the spell ends.</p>
             <p class="indent">When a creature moves into the spell’s area for the first time on a turn or starts its turn there, that creature must succeed on a Constitution saving throw or take 4d10 radiant damage, and it suffers one level of exhaustion and emits a dim, greenish light in a 5-foot radius. This light makes it impossible for the creature to benefit from being invisible. The light and any levels of exhaustion caused by this spell go away when the spell ends.</p>
@@ -1568,7 +1568,7 @@
         </setters>
     </element>
     <element name="Snare" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_SNARE">
-        <supports>Druid, Ranger, Wizard, Artificer</supports>
+        <supports>Druid, Ranger, Wizard, Artificer, Spell Saving Throw</supports>
         <description>
             <p>As you cast this spell, you use the rope to create a circle with a 5-foot radius on the ground or the floor. When you finish casting, the rope disappears and the circle becomes a magic trap.</p>
             <p class="indent">This trap is nearly invisible, requiring a successful Intelligence (Investigation) check against your spell save DC to be discerned.</p>
@@ -1592,7 +1592,7 @@
         </setters>
     </element>
     <element name="Snilloc’s Snowball Swarm" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_SNILLOCS_SNOWBALL_SWARM">
-        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight)</supports>
+        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>A flurry of magic snowballs erupts from a point you choose within range. Each creature in a 5-foot-radius sphere centered on that point must make a Dexterity saving throw. A creature takes 3d6 cold damage on a failed save, or half as much damage on a successful one.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.</p>
@@ -1638,7 +1638,7 @@
         </setters>
     </element>
     <element name="Steel Wind Strike" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_STEEL_WIND_STRIKE">
-        <supports>Ranger, Wizard</supports>
+        <supports>Ranger, Wizard, Spell Attack</supports>
         <description>
             <p>You flourish the weapon used in the casting and then vanish to strike like the wind. Choose up to five creatures you can see within range. Make a melee spell attack against each target. On a hit, a target takes 6d10 force damage.</p>
             <p class="indent">You can then teleport to an unoccupied space you can see within 5 feet of one of the targets you hit or missed.</p>
@@ -1659,7 +1659,7 @@
         </setters>
     </element>
     <element name="Storm Sphere" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_STORM_SPHERE">
-        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight)</supports>
+        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>A 20-foot-radius sphere of whirling air springs into existence centered on a point you choose within range. The sphere remains for the spell’s duration. Each creature in the sphere when it appears or that ends its turn there must succeed on a Strength saving throw or take 2d6 bludgeoning damage. The sphere’s space is difficult terrain.</p>
             <p class="indent">Until the spell ends, you can use a bonus action on each of your turns to cause a bolt of lightning to leap from the center of the sphere toward one creature you choose within 60 feet of the center. Make a ranged spell attack. You have advantage on the attack roll if the target is in the sphere. On a hit, the target takes 4d6 lightning damage.</p>
@@ -1682,7 +1682,7 @@
         </setters>
     </element>
     <element name="Summon Greater Demon" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_SUMMON_GREATER_DEMON">
-        <supports>Warlock, Wizard</supports>
+        <supports>Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You utter foul words, summoning one demon from the chaos of the Abyss. You choose the demon’s type, which must be one of challenge rating 5 or lower, such as a shadow demon or a barlgura. The demon appears in an unoccupied space you can see within range, and the demon disappears when it drops to 0 hit points or when the spell ends.</p>
             <p class="indent">Roll initiative for the demon, which has its own turns. When you summon it and on each of your turns thereafter, you can issue a verbal command to it (requiring no action on your part), telling it what it must do on its next turn. If you issue no command, it spends its turn attacking any creature within reach that has attacked it.</p>
@@ -1733,7 +1733,7 @@
         </setters>
     </element>
     <element name="Synaptic Static" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_SYNAPTIC_STATIC">
-        <supports>Bard, Sorcerer, Warlock, Wizard</supports>
+        <supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You choose a point within range and cause psychic energy to explode there. Each creature in a 20 foot radius sphere centered on that point must make an Intelligence saving throw. A creature with an Intelligence score of 2 or lower can’t be affected by this spell. A target takes 8d6 psychic damage on a failed save, or half as much damage on a successful one.</p>
             <p class="indent">After a failed save, a target has muddled thoughts for 1 minute. During that time, it rolls a d6 and subtracts the number rolled from all its attack rolls and ability checks, as well as its Constitution saving throws to maintain concentration. The target can make an Intelligence saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
@@ -1754,7 +1754,7 @@
         </setters>
     </element>
     <element name="Temple of the Gods" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_TEMPLE_OF_THE_GODS">
-        <supports>Cleric</supports>
+        <supports>Cleric, Spell Saving Throw</supports>
         <description>
             <p>You cause a temple to shimmer into existence on ground you can see within range. The temple must fit within an unoccupied cube of space, up to 120 feet on each side. The temple remains until the spell ends. It is dedicated to whatever god, pantheon, or philosophy is represented by the holy symbol used in the casting.</p>
             <p class="indent">You make all decisions about the temples appearance. The interior is enclosed by a floor, walls, and a roof, with one door granting access to the interior and as many windows as you wish. Only you and any creatures you designate when you cast the spell can open or close the door.</p>
@@ -1781,7 +1781,7 @@
         </setters>
     </element>
     <element name="Tenser’s Transformation" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_TENSERS_TRANSFORMATION">
-        <supports>Wizard</supports>
+        <supports>Wizard, Spell Saving Throw</supports>
         <description>
             <p>You endow yourself with endurance and martial prowess fueled by magic. Until the spell ends, you can’t cast spells, and you gain the following benefits:</p>
             <ul>
@@ -1810,7 +1810,7 @@
         </setters>
     </element>
     <element name="Thunderclap" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_THUNDERCLAP">
-        <supports>Bard, Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight), Artificer</supports>
+        <supports>Bard, Druid, Sorcerer, Warlock, Wizard, Rogue (Arcane Trickster), Fighter (Eldritch Knight), Artificer, Spell Saving Throw</supports>
         <description>
             <p>You create a burst of thunderous sound, which can be heard 100 feet away. Each creature other than you within range, other than you, must succeed on a Constitution saving throw or take 1d6 thunder damage.</p>
             <p class="indent">The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -1831,7 +1831,7 @@
         </setters>
     </element>
     <element name="Thunder Step" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_THUNDER_STEP">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You teleport yourself to an unoccupied space you can see within range. Immediately after you disappear, a thunderous boom sounds. and each creature within 10 feet of the space you left must make a Constitution saving throw, taking 3d10 thunder damage on a failed save, or half as much damage on a successful one. The thunder can be heard from up to 300 feet away.</p>
             <p class="indent">You can bring along objects as long as their weight doesn’t exceed what you can carry. You can also teleport one willing creature of your size or smaller who is carrying gear up to its carrying capacity. The creature must be within 5 feet of you when you cast this spell, and there must be an unoccupied space within 5 feet of your destination space for the creature to appear in; otherwise, the creature is left behind.</p>
@@ -1853,7 +1853,7 @@
         </setters>
     </element>
     <element name="Tidal Wave" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_TIDAL_WAVE">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You conjure up a wave of water that crashes down on an area within range. The area can be up to 30 feet long, up to 10 feet wide, and up to 10 feet tall. Each creature in that area must make a Dexterity saving throw. On a failure, a creature takes 4d8 bludgeoning damage and is knocked prone. On a successful save, a creature takes half as much damage and isn’t knocked prone. The water then spreads out across the ground in all directions, extinguishing unprotected flames within 30 feet of it, and then it vanishes.</p>
         </description>
@@ -1896,7 +1896,7 @@
         </setters>
     </element>
     <element name="Toll the Dead" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_TOLL_THE_DEAD">
-        <supports>Cleric, Warlock, Wizard</supports>
+        <supports>Cleric, Warlock, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You point at one creature you can see within range, and the sound of a dolorous bell fills the air around it for a moment. The target must succeed on a Wisdom saving throw or take 1d8 necrotic damage. If the target is missing any of its hit points, it instead takes 1d12 necrotic damage.</p>
             <p class="indent">The spell’s damage increases by one die when you reach 5th level (2d8 or 2d12), 11th level (3d8 or 3d12), and 17th level (4d8 or 4d12).</p>
@@ -1917,7 +1917,7 @@
         </setters>
     </element>
     <element name="Transmute Rock" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_TRANSMUTE_ROCK">
-        <supports>Druid, Wizard, Artificer</supports>
+        <supports>Druid, Wizard, Artificer, Spell Saving Throw</supports>
         <description>
             <p>You choose an area of stone or mud that you can see that fits within a 40-foot cube and is within range, and choose one of the following effects.</p>
             <p class="indent">Transmute Rock to Mud: Nonmagical rock of any sort in the area becomes an equal volume of thick, flowing mud that remains for the spell’s duration.</p>
@@ -1941,7 +1941,7 @@
         </setters>
     </element>
     <element name="Vitriolic Sphere" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_VITRIOLIC_SPHERE">
-        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight)</supports>
+        <supports>Sorcerer, Wizard, Fighter (Eldritch Knight), Spell Saving Throw</supports>
         <description>
             <p>You point at a location within range, and a glowing 1-foot ball of emerald acid streaks there and explodes in a 20-foot radius sphere. Each creature in that area must make a Dexterity saving throw. On a failed save, a creature takes 10d4 acid damage and another 5d4 acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage and no damage at the end of its next turn.</p>
             <p class="indent"><b><i>At Higher Levels. </i></b>When you cast this spell using a spell slot of 5th level or higher, the initial damage increases by 2d4 for each slot level above 4th.</p>
@@ -1962,7 +1962,7 @@
         </setters>
     </element>
     <element name="Wall of Light" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WALL_OF_LIGHT">
-        <supports>Sorcerer, Warlock, Wizard</supports>
+        <supports>Sorcerer, Warlock, Wizard, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>A shimmering wall of bright light appears at a point you choose within range. The wall appears in any orientation you choose: horizontally, vertically, or diagonally. It can be free floating, or it can rest on a solid surface. The wall can be up to 60 feet long, 10 feet high, and 5 feet thick. The wall blocks line of sight, but creatures and objects can pass through it. It emits bright light out to 120 feet and dim light for an additional 120 feet.</p>
             <p class="indent">When the wall appears, each creature in its area must make a Constitution saving throw. On a failed save, a creature takes 4d8 radiant damage, and it is blinded for 1 minute. On a successful save, it takes half as much damage and isn’t blinded. A blinded creature can make a Constitution saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
@@ -2055,7 +2055,7 @@
         </setters>
     </element>
     <element name="Watery Sphere" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WATERY_SPHERE">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>You conjure up a sphere of water with a 5-foot radius on a point you can see within range. The sphere can hover, but no more than 10 feet off the ground. The sphere remains for the spell’s duration.</p>
             <p class="indent">Any creature in the sphere’s space must make a Strength saving throw. On a successful save, a creature is ejected from that space to the nearest unoccupied space of the creature’s choice outside the sphere. A Huge or larger creature succeeds on the saving throw automatically. On a failed save, a creature is restrained by the sphere and is engulfed by the water. At the end of each of its turns, a restrained target can repeat the saving throw, ending the effect on itself on a success.</p>
@@ -2079,7 +2079,7 @@
         </setters>
     </element>
     <element name="Whirlwind" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WHIRLWIND">
-        <supports>Druid, Sorcerer, Wizard</supports>
+        <supports>Druid, Sorcerer, Wizard, Spell Saving Throw</supports>
         <description>
             <p>A whirlwind howls down to a point on the ground you specify. The whirlwind is a 10-foot-radius, 30-foot-high cylinder centered on that point. Until the spell ends, you can use your action to move the whirlwind up to 30 feet in any direction along the ground. The whirlwind sucks up any Medium or smaller objects that aren’t secured to anything and that aren’t worn or carried by anyone.</p>
             <p class="indent">A creature must make a Dexterity saving throw the first time on a turn that it enters the whirlwind or that the whirlwind enters its space, including when the whirlwind first appears. A creature takes 10d6 bludgeoning damage on a failed save, or half as much damage on a successful one. In addition, a Large or smaller creature that fails the save must succeed on a Strength saving throw or become restrained in the whirlwind until the spell ends. When a creature starts its turn restrained by the whirlwind, the creature is pulled 5 feet higher inside it, unless the creature is at the top. A restrained creature moves with the whirlwind and falls when the spell ends, unless the creature has some means to stay aloft.</p>
@@ -2101,7 +2101,7 @@
         </setters>
     </element>
     <element name="Word of Radiance" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WORD_OF_RADIANCE">
-        <supports>Cleric</supports>
+        <supports>Cleric, Spell Saving Throw</supports>
         <description>
             <p>You utter a divine word, and burning radiance erupts from you. Each creature of your choice that you can see within range must succeed on a Constitution saving throw or take 1d6 radiant damage.</p>
             <p class="indent">The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
@@ -2122,7 +2122,7 @@
         </setters>
     </element>
     <element name="Wrath of Nature" type="Spell" source="Xanathar’s Guide to Everything" id="ID_XGTE_SPELL_WRATH_OF_NATURE">
-        <supports>Druid, Ranger</supports>
+        <supports>Druid, Ranger, Spell Attack, Spell Saving Throw</supports>
         <description>
             <p>You call out to the spirits of nature to rouse them against your enemies. Choose a point you can see within range. The spirits cause trees, rocks, and grasses in a 60-foot cube centered on that point to become animated until the spell ends.</p>
             <p class="indent">Grasses and Undergrowth. Any area of ground in the cube that is covered by grass or undergrowth is difficult terrain for your enemies.</p>


### PR DESCRIPTION
Resolves #38 

Adds 2 supports to spells:
1. Spell Attack - This is for any spell that has a Melee/Range Spell Attack roll.
2. Spell Saving Throw - This is for any spell that has a Saving Throw that would prevent/reduce something happening to the target or caster.

Anyone with the Spell Sniper Feat may be required to reselect the granted spell.