### PR TITLE
[TCOE] Aberrant Mind and Clockwork Additional Spells Fix

### DIFF
--- a/supplements/tashas-cauldron-of-everything/archetypes/sorcerer-aberrant.xml
+++ b/supplements/tashas-cauldron-of-everything/archetypes/sorcerer-aberrant.xml
@@ -4,7 +4,7 @@
 		<name>Aberrant Mind</name>
 		<description>The Aberrant Mind from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="sorcerer-aberrant.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/archetypes/sorcerer-aberrant.xml" />
 		</update>
 	</info>
@@ -62,17 +62,17 @@
 			<description>Whenever you gain a sorcerer level, you can replace one spell you gained from this feature with another spell of the same level. The new spell must be a divination or a enchantment spell from the sorcerer, warlock, or wizard spell list.</description>
 		</sheet>
 		<rules>
-			<select type="Spell" name="Spell, Psionic Spells" supports="1,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Arms of Hadar" level="1" default="ID_PHB_SPELL_ARMS_OF_HADAR" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="1,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Dissonant Whispers" level="1" default="ID_PHB_SPELL_DISSONANT_WHISPERS" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="0,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)" level="1" default="ID_WOTC_TCOE_SPELL_MIND_SLIVER" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="2,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Calm Emotions" level="3" default="ID_PHB_SPELL_CALM_EMOTIONS" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="2,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)" level="3" default="ID_PHB_SPELL_DETECT_THOUGHTS" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="3,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Hunger of Hadar" level="5" default="ID_PHB_SPELL_HUNGER_OF_HADAR" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="3,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Sending" level="5" default="ID_PHB_SPELL_SENDING" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="4,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Evards Black Tentacles" level="7" default="ID_PHB_SPELL_EVARDS_BLACK_TENTACLES" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="4,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Summon Aberration" level="7" default="ID_WOTC_TCOE_SPELL_SUMMON_ABERRATION" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="5,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)" level="9" default="ID_PHB_SPELL_RARYS_TELEPATHIC_BOND" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Psionic Spells" supports="5,(Divination||Enchantment),(($(spellcasting:list))||Warlock||Wizard)||Telekinesis" level="9" default="ID_PHB_SPELL_TELEKINESIS" spellcasting="Sorcerer" />
+			<select type="Spell" name="Cantrip (Psionic Spells)" supports="0,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)" level="1" default="ID_WOTC_TCOE_SPELL_MIND_SLIVER" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="1st Additional Spell (Psionic Spells)" supports="1,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Arms of Hadar" level="1" default="ID_PHB_SPELL_ARMS_OF_HADAR" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="2nd Additional Spell (Psionic Spells)" supports="1,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Dissonant Whispers" level="1" default="ID_PHB_SPELL_DISSONANT_WHISPERS" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="3rd Additional Spell (Psionic Spells)" supports="2,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Calm Emotions" level="3" default="ID_PHB_SPELL_CALM_EMOTIONS" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="4th Additional Spell (Psionic Spells)" supports="2,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)" level="3" default="ID_PHB_SPELL_DETECT_THOUGHTS" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="5th Additional Spell (Psionic Spells)" supports="3,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Hunger of Hadar" level="5" default="ID_PHB_SPELL_HUNGER_OF_HADAR" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="6th Additional Spell (Psionic Spells)" supports="3,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Sending" level="5" default="ID_PHB_SPELL_SENDING" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="7th Additional Spell (Psionic Spells)" supports="4,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Evards Black Tentacles" level="7" default="ID_PHB_SPELL_EVARDS_BLACK_TENTACLES" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="8th Additional Spell (Psionic Spells)" supports="4,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Summon Aberration" level="7" default="ID_WOTC_TCOE_SPELL_SUMMON_ABERRATION" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="9th Additional Spell (Psionic Spells)" supports="5,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)" level="9" default="ID_PHB_SPELL_RARYS_TELEPATHIC_BOND" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="10th Additional Spell (Psionic Spells)" supports="5,(Divination||Enchantment),(Sorcerer||Warlock||Wizard)||Telekinesis" level="9" default="ID_PHB_SPELL_TELEKINESIS" spellcasting="Sorcerer" allowReplace="false" />
 		</rules>
 	</element>
 	<element name="Telepathic Speech" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_ABERRANT_MIND_TELEPATHIC_SPEECH">

--- a/supplements/tashas-cauldron-of-everything/archetypes/sorcerer-clockwork.xml
+++ b/supplements/tashas-cauldron-of-everything/archetypes/sorcerer-clockwork.xml
@@ -4,7 +4,7 @@
 		<name>Clockwork Soul</name>
 		<description>The Clockwork Soul from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="sorcerer-clockwork.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/archetypes/sorcerer-clockwork.xml" />
 		</update>
 	</info>
@@ -61,16 +61,16 @@
 			<description>Whenever you gain a sorcerer level, you can replace one spell you gained from this feature with another spell of the same level. The new spell must be an abjuration or a transmutation spell from the sorcerer, warlock, or wizard spell list.</description>
 		</sheet>
 		<rules>
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)" level="1" default="ID_PHB_SPELL_ALARM" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)" level="1" default="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)||Aid" level="3" default="ID_PHB_SPELL_AID" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)||Lesser Restoration" level="3" default="ID_PHB_SPELL_LESSER_RESTORATION" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)" level="5" default="ID_PHB_SPELL_DISPEL_MAGIC" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)" level="5" default="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)||Freedom of Movement" level="7" default="ID_PHB_SPELL_FREEDOM_OF_MOVEMENT" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)||Summon Construct" level="7" default="ID_WOTC_TCOE_SPELL_SUMMON_CONSTRUCT" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)||Greater Restoration" level="9" default="ID_PHB_SPELL_GREATER_RESTORATION" spellcasting="Sorcerer" />
-			<select type="Spell" name="Spell, Clockwork Magic" supports="(Abjuration||Transmutation),(($(spellcasting:list))||Warlock||Wizard)||Wall of Force" level="9" default="ID_PHB_SPELL_WALL_OF_FORCE" spellcasting="Sorcerer" />
+			<select type="Spell" name="1st Additional Spell (Clockwork Magic)" supports="1,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)" level="1" default="ID_PHB_SPELL_ALARM" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="2nd Additional Spell (Clockwork Magic)" supports="1,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)" level="1" default="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="3rd Additional Spell (Clockwork Magic)" supports="2,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)||Aid" level="3" default="ID_PHB_SPELL_AID" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="4th Additional Spell (Clockwork Magic)" supports="2,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)||Lesser Restoration" level="3" default="ID_PHB_SPELL_LESSER_RESTORATION" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="5th Additional Spell (Clockwork Magic)" supports="3,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)" level="5" default="ID_PHB_SPELL_DISPEL_MAGIC" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="6th Additional Spell (Clockwork Magic)" supports="3,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)" level="5" default="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="7th Additional Spell (Clockwork Magic)" supports="4,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)||Freedom of Movement" level="7" default="ID_PHB_SPELL_FREEDOM_OF_MOVEMENT" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="8th Additional Spell (Clockwork Magic)" supports="4,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)||Summon Construct" level="7" default="ID_WOTC_TCOE_SPELL_SUMMON_CONSTRUCT" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="9th Additional Spell (Clockwork Magic)" supports="5,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)||Greater Restoration" level="9" default="ID_PHB_SPELL_GREATER_RESTORATION" spellcasting="Sorcerer" allowReplace="false" />
+			<select type="Spell" name="10th Additional Spell (Clockwork Magic)" supports="5,(Abjuration||Transmutation),(Sorcerer||Warlock||Wizard)||Wall of Force" level="9" default="ID_PHB_SPELL_WALL_OF_FORCE" spellcasting="Sorcerer" allowReplace="false" />
 		</rules>
 	</element>
 	<element name="Restore Balance" type="Archetype Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_ARCHETYPE_FEATURE_CLOCKWORK_SOUL_RESTORE_BALANCE">


### PR DESCRIPTION
• changed name of the spell selects in order to avoid conflicts on load.
• changed supports from `($(spellcasting:list)` to `Sorcerer`, so expanded spell list wouldn't add upon selection.
• added `allowReplace="false"` so app wouldn't replace supports with that function.

Warning: Once this pull merged, old characters with changed spells from these features would need to re-select them again.