### PR TITLE
[PHB] Typo Fixes

### DIFF
--- a/core/players-handbook/backgrounds/background-criminal.xml
+++ b/core/players-handbook/backgrounds/background-criminal.xml
@@ -4,7 +4,7 @@
 		<name>Criminal</name>
 		<description>Criminal Background</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.0.7">
+		<update version="0.0.8">
 			<file name="background-criminal.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/backgrounds/background-criminal.xml" />
 		</update>
 	</info>
@@ -83,7 +83,7 @@
 				<item id="3">Something important was taken from me, and I aim to steal it back.</item>
 				<item id="4">I will become the greatest thief that ever lived.</item>
 				<item id="5">I’m guilty of a terrible crime. I hope I can redeem myself for it.</item>
-				<item id="6">Someone I loved died because of I mistake I made. That will never happen again.</item>
+				<item id="6">Someone I loved died because of a mistake I made. That will never happen again.</item>
 			</select>
 			<select type="List" name="Flaw">
 				<item id="1">When I see something valuable, I can’t think about anything but how to steal it.</item>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name>Spells</name>
-		<update version="0.4.9">
+		<update version="0.4.10">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/spells.xml" />
 		</update>
 	</info>
@@ -2829,7 +2829,7 @@
 		<supports>Bard, Sorcerer, Warlock, Wizard, Spell Saving Throw</supports>
 		<description>
 			<p>For the spell’s duration, your eyes become an inky void imbued with dread power. One creature of your choice within 60 feet of you that you can see must succeed on a Wisdom saving throw or be affected by one of the following effects of your choice for the duration. On each of your turns until the spell ends, you can use your action to target another creature but can’t target a creature again if it has succeeded on a saving throw against this casting of eyebite.</p>
-			<p class="indent"><b><i>Asleep.</i></b> The target galls unconscious. It wakes up if it takes any damage or if another creature uses its action to shake the sleeper awake.</p>
+			<p class="indent"><b><i>Asleep.</i></b> The target falls unconscious. It wakes up if it takes any damage or if another creature uses its action to shake the sleeper awake.</p>
 			<p class="indent"><b><i>Panicked.</i></b> The target is frightened of you. On each of its turns, the frightened creature must take the Dash action and move away from you by the safest and shortest available route, unless there is nowhere to move. If the target moves to a place at least 60 feet away from you where it can no longer see you, this effect ends.</p>
 			<p class="indent"><b><i>Sickened.</i></b> The target has disadvantage on attack rolls and ability checks. At the end of each of its turns, it can make another Wisdom saving throw. If it succeeds, the effect ends.</p>
 		</description>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name>Spells</name>
-		<update version="0.4.10">
+		<update version="0.5.0">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/spells.xml" />
 		</update>
 	</info>

--- a/supplements/sword-coast-adventurers-guide/backgrounds/background-urbanbountyhunter.xml
+++ b/supplements/sword-coast-adventurers-guide/backgrounds/background-urbanbountyhunter.xml
@@ -4,7 +4,7 @@
 		<name>Urban Bounty Hunter</name>
 		<description>Urban Bounty Hunter Background</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/sc-adventurers-guide">Wizards of the Coast</author>
-		<update version="0.1.4">
+		<update version="0.1.5">
 			<file name="background-urbanbountyhunter.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/sword-coast-adventurers-guide/backgrounds/background-urbanbountyhunter.xml" />
 		</update>
 	</info>
@@ -56,7 +56,7 @@
 				<item id="3">Something important was taken from me, and I aim to steal it back.</item>
 				<item id="4">I will become the greatest thief that ever lived.</item>
 				<item id="5">I’m guilty of a terrible crime. I hope I can redeem myself for it.</item>
-				<item id="6">Someone I loved died because of I mistake I made. That will never happen again.</item>
+				<item id="6">Someone I loved died because of a mistake I made. That will never happen again.</item>
 			</select>
 			<select type="List" name="Flaw">
 				<item id="1">When I see something valuable, I can’t think about anything but how to steal it.</item>


### PR DESCRIPTION
Typo fixes for Criminal and Urban Bounty Hunter backgrounds and in the Asleep spell description.
