### PR TITLE
Small Typo Fix class-wizard.xml

### DIFF
--- a/core/players-handbook/classes/class-wizard.xml
+++ b/core/players-handbook/classes/class-wizard.xml
@@ -214,7 +214,7 @@
 			<p class="indent">For example, if you’re a 4th-level wizard, you can recover up to two levels worth of spell slots. You can recover either a 2nd-level spell slot or two 1st-level spell slots.</p>
 		</description>
 		<sheet>
-			<description>Once per day when you finish a short rest, you can choose expended spell slots up to 5th level to recover. The spell slots can have a combined level that is equal to or less than {{level:wizard:half:up}}.</description>
+			<description>Once per day when you finish a short rest, you can choose expended spell slots up to 6th level to recover. The spell slots can have a combined level that is equal to or less than {{level:wizard:half:up}}.</description>
 		</sheet>
 	</element>
 	<element name="Arcane Tradition" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_PHB_CLASS_FEATURE_WIZARD_ARCANE_TRADITION">


### PR DESCRIPTION
Tiny typo I saw. The regular description in this file says 6th level but the sheet description says 5th level. Checked the PHB to confirm it is 6th level.