### PR TITLE
Tether Essence Spell Description Typo

### DIFF
--- a/supplements/explorers-guide-to-wildemount/spells.xml
+++ b/supplements/explorers-guide-to-wildemount/spells.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-        <update version="0.0.3">
+        <update version="0.0.4">
             <file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/explorers-guide-to-wildemount/spells.xml" />
         </update>
     </info>
@@ -287,7 +287,7 @@
             <set name="hasVerbalComponent">true</set>
             <set name="hasSomaticComponent">true</set>
             <set name="hasMaterialComponent">true</set>
-            <set name="materialComponent">a spool of platinum cord worth at least 250 fp, which the spell consumes</set>
+            <set name="materialComponent">a spool of platinum cord worth at least 250 gp, which the spell consumes</set>
             <set name="isConcentration">true</set>
             <set name="isRitual">false</set>
         </setters>


### PR DESCRIPTION
Changed "Components: V, S, M (a spool of platinum cord worth at least 250 fp, which the spell consumes)" to "Components: V, S, M (a spool of platinum cord worth at least 250 gp, which the spell consumes)" & the update version