### PR TITLE
[PHB] Archetype Feature Typo - Divine Soul Sorcerer

### DIFF
--- a/supplements/xanathars-guide-to-everything/archetypes/sorcerer-divinesoul.xml
+++ b/supplements/xanathars-guide-to-everything/archetypes/sorcerer-divinesoul.xml
@@ -4,7 +4,7 @@
 		<name>Divine Soul</name>
 		<description>The Divine Soul Sorcerous Origin from Xanathar’s Guide to Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="sorcerer-divinesoul.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/xanathars-guide-to-everything/archetypes/sorcerer-divinesoul.xml" />
 		</update>
 	</info>
@@ -42,7 +42,7 @@
 				<tr><td>Good</td><td><i>cure wounds</i></td></tr>
 				<tr><td>Evil</td><td><i>inflict wounds</i></td></tr>
 				<tr><td>Law</td><td><i>bless</i></td></tr>
-				<tr><td>Chaos</td><td><i>bone</i></td></tr>
+				<tr><td>Chaos</td><td><i>bane</i></td></tr>
 				<tr><td>Neutrality</td><td><i>protection from evil and good</i></td></tr>
 			</table>
 		</description>


### PR DESCRIPTION
Changed "Bone" to "Bane" (despite the comedic value of said-typo) in the Divine Magic Affinity-Spell table + Update Version Correction