### PR TITLE
[ERLW] Misstyped Magic Item Description

### DIFF
--- a/supplements/eberron-rising-from-the-last-war/items.xml
+++ b/supplements/eberron-rising-from-the-last-war/items.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="items.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/eberron-rising-from-the-last-war/items.xml" />
 		</update>
 	</info>
@@ -360,7 +360,7 @@
 	</element>
 	<element name="Keycharm" type="Magic Item" source="Eberron: Rising from the Last War" id="ID_WOTC_ERLW_MAGIC_ITEM_KEYCHARM">
 		<description>
-			<p>This small stylized key plays a vital role in the work of House Kundarak. If you cast the alarm, arcane lock, or glyph of warding spell, you can tie the effect to the keycharm so that whoever holds it receives the notification from the alarm spell, bypasses the lock of the arcane Jock spell, or avoids triggering the glyph placed by the glyph of warding spell. In addition, the holder (who needn’t be attuned to the item) can take an action to end any one spell tied to it, provided the holder knows the command word you set for ending the tied spells. The keycharm can have up to three tied spells at one time.</p>
+			<p>This small stylized key plays a vital role in the work of House Kundarak. If you cast the alarm, arcane lock, or glyph of warding spell, you can tie the effect to the keycharm so that whoever holds it receives the notification from the alarm spell, bypasses the lock of the arcane lock spell, or avoids triggering the glyph placed by the glyph of warding spell. In addition, the holder (who needn’t be attuned to the item) can take an action to end any one spell tied to it, provided the holder knows the command word you set for ending the tied spells. The keycharm can have up to three tied spells at one time.</p>
 		</description>
 		<setters>
 			<set name="category">Wondrous Items</set>


### PR DESCRIPTION
Changed line 363: 			<p>....  bypasses the lock of the arcane Jock spell, or avoids triggering the glyph placed by the</p>
to
 			                        <p>....  bypasses the lock of the arcane lock spell, or avoids triggering the glyph placed by the</p>