### PR TITLE
[ERLW] Revenant Blade requirement fix

### DIFF
--- a/supplements/eberron-rising-from-the-last-war/feats.xml
+++ b/supplements/eberron-rising-from-the-last-war/feats.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.2">
+		<update version="0.0.3">
 			<file name="feats.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/eberron-rising-from-the-last-war/feats.xml" />
 		</update>
 	</info>	
 	<element name="Revenant Blade" type="Feat" source="Eberron: Rising from the Last War" id="ID_WOTC_ERLW_FEAT_REVENANT_BLADE">
-		<requirements>ID_RACE_ELF||ID_WOTC_TCOE_RACE_CUSTOM_LINEAGE</requirements>
+		<requirements>ID_RACE_ELF||ID_WOTC_TCOE_RACE_CUSTOM_LINEAGE||ID_INTERNAL_RACIAL_TRAIT_TYPE_HUMANOID_ELF</requirements>
 		<prerequisite>Elf</prerequisite>
 		<description>
 			<p><em>Prerequisite: Elf</em></p>


### PR DESCRIPTION
Added the elf grant to the requirements so that MotM eladrin, shadar-kai, and sea elf can select the feat, along with astral elf