### PR TITLE
[DMG]Added Missing Spell Attack Bonus to Staff of the Woodlands

### DIFF
--- a/core/dungeon-masters-guide/items/items-staffs.xml
+++ b/core/dungeon-masters-guide/items/items-staffs.xml
@@ -4,7 +4,7 @@
 		<name>Staffs</name>
 		<description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="items-staffs.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/dungeon-masters-guide/items/items-staffs.xml" />
 		</update>
 	</info>
@@ -141,6 +141,9 @@
 			<set name="enhancement">2</set>
 			<set name="charges">10</set>
 		</setters>
+		<rules>
+			<stat name="spellcasting:attack" value="2" />
+		</rules>
 	</element>
 	<element name="Staff of Fire" type="Magic Item" source="Dungeon Master’s Guide" id="ID_WOTC_DMG_MAGIC_ITEM_STAFF_OF_FIRE">
 		<description>


### PR DESCRIPTION
Staff of the Woodlands grants a +2 to spell attack, which wasn't honored by Aurora so far