### PR TITLE
[SCAG] Fix alternate proficiencies for Royal Envoy

### DIFF
--- a/supplements/sword-coast-adventurers-guide/classes/fighter-purpledragonknight.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/fighter-purpledragonknight.xml
@@ -4,7 +4,7 @@
 		<name>Purple Dragon Knight</name>
 		<description>Purple Dragon Knight archetype from the Sword Coast Adventurer’s Guide.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/sc-adventurers-guide">Wizards of the Coast</author>
-		<update version="0.0.7">
+		<update version="0.0.8">
 			<file name="fighter-purpledragonknight.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/sword-coast-adventurers-guide/classes/fighter-purpledragonknight.xml" />
 		</update>
 	</info>
@@ -54,7 +54,7 @@
 			<description>A Purple Dragon knight serves as an envoy of the Cormyrean crown. Knights of high standing are expected to conduct themselves with grace</description>
 		</sheet>
 		<rules>
-			<select type="Proficiency" name="Royal Envoy" supports="ID_PROFICIENCY_SKILL_ANIMALHANDLING|ID_PROFICIENCY_SKILL_INSIGHT|ID_PROFICIENCY_SKILL_INSIGHT|ID_PROFICIENCY_SKILL_PERFORMANCE|ID_PROFICIENCY_SKILL_PERSUASION" default="ID_PROFICIENCY_SKILL_PERSUASION" default-behaviour="force" />
+			<select type="Proficiency" name="Royal Envoy" supports="ID_PROFICIENCY_SKILL_ANIMALHANDLING|ID_PROFICIENCY_SKILL_INSIGHT|ID_PROFICIENCY_SKILL_INTIMIDATION|ID_PROFICIENCY_SKILL_PERFORMANCE|ID_PROFICIENCY_SKILL_PERSUASION" default="ID_PROFICIENCY_SKILL_PERSUASION" default-behaviour="force" />
 			<!-- requirements set due to not implemented default behaviour, would mark as proficienct when user selected something else, can be removed after default behaviour is implemented -->
 			<stat name="persuasion:proficiency" value="proficiency" bonus="double" requirements="ID_PROFICIENCY_SKILL_PERSUASION"/>
 		</rules>


### PR DESCRIPTION
According to the description of Royal Envoy, if you already have proficiency in Persuasion you can pick a replacement from the following list:
> Animal Handling, Insight, Intimidation, or Performance.

However, the machine-readable rule seems to have accidentally included Insight twice while omitting Intimidation.