### PR TITLE
[BoMT] Fixed source for gifts

### DIFF
--- a/supplements.index
+++ b/supplements.index
@@ -4,7 +4,7 @@
 		<name>Supplements</name>
 		<description>Supplements from Wizards of the Coast to expand your core gaming elements.</description>
 		<author url="http://dnd.wizards.com">Wizards of the Coast</author>
-		<update version="0.6.1">
+		<update version="0.6.2">
 			<file name="supplements.index" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements.index" />
 		</update>
 	</info>

--- a/supplements.index
+++ b/supplements.index
@@ -55,6 +55,7 @@
 		<file name="the-book-of-many-things.index" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/the-book-of-many-things.index" />
 
 		<file name="adventurers-league.index" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/adventurers-league.index" />
+		<file name="dnd-beyond.index" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/dnd-beyond.index" />
 
 		<!-- events -->
 		<file name="extra-life.index" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/extra-life.index" />

--- a/supplements/the-book-of-many-things/items-gifts.xml
+++ b/supplements/the-book-of-many-things/items-gifts.xml
@@ -2,13 +2,13 @@
 <elements>
 	<info>
 		<name>Supernatural Gifts, Blessings and Charms from The Book of Many Things</name>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="items-gifts.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/the-book-of-many-things/items-gifts.xml" />
 		</update>
 	</info>
 
 	<!-- Blessings -->
-	<element name="Blessing of Bloody Might" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_BLESSING_OF_BLOODY_MIGHT">
+	<element name="Blessing of Bloody Might" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_BLESSING_OF_BLOODY_MIGHT">
 		<description>
 			<p>Your Strength score increases by 2, to a maximum of 22.</p>
 			<p class="indent"><strong>Consequence.</strong> The character is cursed with werewolf lycanthropy (see the <i>Monster Manual</i>) until the blessing ends on them. On nights when the moon is full, the cursed character flies into a rage that lasts until dawn; while in this state, the character becomes an NPC under the DM's control.</p>
@@ -25,7 +25,7 @@
 		</rules>
 	</element>
 
-	<element name="Blessing of Lonely Genius" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_BLESSING_OF_LONELY_GENIUS">
+	<element name="Blessing of Lonely Genius" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_BLESSING_OF_LONELY_GENIUS">
 		<description>
 			<p>Your Intelligence score increases by 2, to a maximum of 22.</p>
 			<p class="indent"><strong>Consequence.</strong> The character's intellect rubs old friends the wrong way. Three NPCs of the DM's choice become indifferent or hostile toward the character, and the character automatically fails any Charisma check made to improve their attitudes.</p>
@@ -41,7 +41,7 @@
 		</rules>
 	</element>
 
-	<element name="Blessing of Unearned Riches" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_BLESSING_OF_UNEARNED_RICHES">
+	<element name="Blessing of Unearned Riches" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_BLESSING_OF_UNEARNED_RICHES">
 		<description>
 			<p>The next time you search among or retrieve something from your belongings, you find an unmarked pouch containing five 1,000 gp gemstones.</p>
 			<p class="indent"><strong>Consequence.</strong> The character's new fortune garners unwanted attention from a guild of violent mercenaries, who claim to have been robbed of exactly 5,000 gp worth of gems the same day as the character found the windfall. Every night for the next 7 days, the character is attacked by 1d4 neutral evil veterans. When the attacks end, so does this blessing.</p>
@@ -54,7 +54,7 @@
 	</element>
 
 	<!-- Charms -->
-	<element name="Charm of Balance" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_BALANCE">
+	<element name="Charm of Balance" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_BALANCE">
 		<description>
 			<p>When a creature you can see within 60 feet of you damages you, you can use your reaction to deal an amount of force damage to that creature equal to half the damage you took. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -65,7 +65,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of Euryale" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_EURYALE">
+	<element name="Charm of Euryale" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_EURYALE">
 		<description>
 			<p>As an action, you can unleash a petrifying wave of magic from your eyes in a 30-foot cone. Each creature in that area must make a DC 15 Constitution saving throw. On a failed save, a creature has the petrified condition for 1 hour. On a successful save, a creature is partially turned to stone and has the restrained condition. A restrained creature can repeat the save at the end of each of its turns, ending the effect on itself on a success.</p>
 			<p class="indent">Once you use this charm, it vanishes from you.</p>
@@ -77,7 +77,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of Many Things" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_MANY_THINGS">
+	<element name="Charm of Many Things" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_MANY_THINGS">
 		<description>
 			<p>You are infused with a burst of magic from a Deck of Many Things. As an action, you can touch a willing creature other than yourself and bestow the effect of a single randomly determined card from the deck upon the target. Once you use this charm, it vanishes from you.</p>
 		</description>
@@ -88,7 +88,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of Ruin" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_RUIN">
+	<element name="Charm of Ruin" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_RUIN">
 		<description>
 			<p>As an action, you can touch a nonmagical object, or a section of a larger nonmagical object, that fits in a 5-foot cube. The target is reduced to dust. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -99,7 +99,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Comet" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_COMET">
+	<element name="Charm of the Comet" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_COMET">
 		<description>
 			<p>As an action, you can force a creature you can see within 60 feet of you to focus on you. For 1 minute, creatures other than you and the target are invisible to the target. The effect ends if any creature other than you damages the target or forces the target to make a saving throw. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -110,7 +110,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Donjon" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_DONJON">
+	<element name="Charm of the Donjon" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_DONJON">
 		<description>
 			<p>You can cast <i>Otiluke's Resilient Sphere</i>, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -124,7 +124,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Fates" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_FATES">
+	<element name="Charm of the Fates" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_FATES">
 		<description>
 			<p>You can tug on the threads of fate to tweak circumstance in your favor. After you make an ability check, an attack roll, or a saving throw, you can roll a d10 and add it to the total, potentially turning failure into success. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -135,7 +135,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Flames" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_FLAMES">
+	<element name="Charm of the Flames" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_FLAMES">
 		<description>
 			<p>As an action, you can summon two bearded devils. The summoned devils appear in unoccupied spaces within 60 feet of you, obey your commands, and can't summon other devils. The devils take their turns immediately after yours on the initiative count. A summoned devil remains for 10 minutes, until it or you die, or until you dismiss one or both summoned devils as an action. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -146,7 +146,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Fool" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_FOOL">
+	<element name="Charm of the Fool" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_FOOL">
 		<description>
 			<p>You can cast Major Image, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). When you cast the spell in this way, it lasts its full duration with no concentration required. Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -160,7 +160,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Gem" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_GEM">
+	<element name="Charm of the Gem" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_GEM">
 		<description>
 			<p>As an action, you create a spray of 4d10 gems in a 30-foot cone originating from you. Each creature in that area must make a DC 15 Dexterity saving throw. On a failed save, a creature takes an amount of bludgeoning damage equal to the number of gems created. On a successful save, a creature takes half as much damage. The gems remain after the effect ends, and each one is worth 10 gp. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -171,7 +171,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Jester" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_JESTER">
+	<element name="Charm of the Jester" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_JESTER">
 		<description>
 			<p>You can cast Tasha's Hideous Laughter, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -185,7 +185,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Key" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_KEY">
+	<element name="Charm of the Key" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_KEY">
 		<description>
 			<p>As a bonus action, you can touch a nonmagical melee weapon and imbue it with magic for 1 hour. For the duration, the weapon deals an extra 1d8 force damage on a hit and deals double damage to objects and structures. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -196,7 +196,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Knight" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_KNIGHT">
+	<element name="Charm of the Knight" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_KNIGHT">
 		<description>
 			<p>As an action, you can summon two neutral good knights that are Celestials instead of Humanoids. The knights appear in unoccupied spaces within 60 feet of you and act as your allies. They take their turns immediately after yours on your initiative count. The knights remain for 10 minutes, until they or you die, or until you dismiss one or both of them as an action. Once used three times, the charm vanishes from you.</p>
 		</description>
@@ -207,7 +207,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Moon" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_MOON">
+	<element name="Charm of the Moon" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_MOON">
 		<description>
 			<p>As an action, you make a minor wish. When you do, you create the effects of a spell of 5th level or lower. The spell takes effect as part of this action and requires no spell components. Your Intelligence, Wisdom, or Charisma is the spellcasting ability for this spell (your choice). Once you use this charm, it vanishes from you.</p>
 		</description>
@@ -218,7 +218,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Puzzle" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_PUZZLE">
+	<element name="Charm of the Puzzle" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_PUZZLE">
 		<description>
 			<p>You can cast Hypnotic Pattern, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -232,7 +232,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Rogue" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_ROGUE">
+	<element name="Charm of the Rogue" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_ROGUE">
 		<description>
 			<p>You can cast Mislead, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). When you cast the spell in this way, it lasts its full duration with no concentration required. Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -246,7 +246,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Sage" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_SAGE">
+	<element name="Charm of the Sage" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_SAGE">
 		<description>
 			<p>You can cast Divination, requiring no material components and using your Intelligence as the spellcasting ability. Once you cast the spell three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -260,7 +260,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Skull" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_SKULL">
+	<element name="Charm of the Skull" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_SKULL">
 		<description>
 			<p>As a bonus action, you can transform into a deathly apparition. Your game statistics are replaced by those of a wraith, except for your alignment and personality; your Intelligence, Wisdom, and Charisma scores; and your passive Wisdom (Perception) score and languages. You don't have the wraith's Create Specter ability. Your equipment vanishes when you transform but returns when the transformation ends. The transformation lasts for 1 minute, until your wraith form is reduced to 0 hit points, or until you use a bonus action to end it. If the wraith form is reduced to 0 hit points and there is still damage left over, the remaining damage applies to your normal hit points. Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -274,7 +274,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Star" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_STAR">
+	<element name="Charm of the Star" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_STAR">
 		<description>
 			<p>You can cast Enhance Ability, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). When you cast the spell in this way, it lasts its full duration with no concentration required. Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -288,7 +288,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Sun" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_SUN">
+	<element name="Charm of the Sun" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_SUN">
 		<description>
 			<p>You learn the Light cantrip if you don't already know it. You can cast Sunburst, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). Once used, the charm vanishes from you, and you unlearn the Light cantrip gained from this charm.</p>
 			<div class="reference">
@@ -305,7 +305,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Talons" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_TALONS">
+	<element name="Charm of the Talons" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_TALONS">
 		<description>
 			<p>As an action, you can cast Dispel Magic, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). If you successfully end any spells with it, you gain 1d6 temporary hit points for each spell level of the highest-level spell ended. Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -319,7 +319,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Throne" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_THRONE">
+	<element name="Charm of the Throne" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_THRONE">
 		<description>
 			<p>You can cast Mordenkainen's Magnificent Mansion, requiring no spell components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). Once used three times, the charm vanishes from you.</p>
 			<div class="reference">
@@ -333,7 +333,7 @@
 		</setters>
 	</element>
 
-	<element name="Charm of the Void" type="Item" source="Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_VOID">
+	<element name="Charm of the Void" type="Item" source="The Book of Many Things" id="ID_WOTC_BOMT_ITEM_CHARM_OF_THE_VOID">
 		<description>
 			<p>You can cast Banishment, requiring no material components and using your Intelligence, Wisdom, or Charisma as the spellcasting ability (your choice). Once used three times, the charm vanishes from you.</p>
 			<div class="reference">


### PR DESCRIPTION
The source was labelled as "Book of Many Things" instead of "The Book of Many Things".

This PR also adds dnd-beyond.index to supplements.index.