### PR TITLE
[GotG] Fixed background feature sources

### DIFF
--- a/supplements/glory-of-the-giants/backgrounds/background-giant-foundling.xml
+++ b/supplements/glory-of-the-giants/backgrounds/background-giant-foundling.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="background-giant-foundling.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/glory-of-the-giants/backgrounds/background-giant-foundling.xml" />
 		</update>
 	</info>
@@ -65,7 +65,7 @@
 			</select>
 		</rules>
 	</element>
-	<element name="Feature: Strike of the Giants" type="Background Feature" source="Eberron: Rising from the Last War" id="ID_WOTC_GOTG_BACKGROUND_FEATURE_GIANT_FOUNDLING_STRIKE_OF_THE_GIANTS">
+	<element name="Feature: Strike of the Giants" type="Background Feature" source="Bigby Presents: Glory of the Giants" id="ID_WOTC_GOTG_BACKGROUND_FEATURE_GIANT_FOUNDLING_STRIKE_OF_THE_GIANTS">
 		<supports>Background Feature</supports>
 		<description>
 			<p>You gain the Strike of the Giants feat.</p>

--- a/supplements/glory-of-the-giants/backgrounds/background-rune-carver.xml
+++ b/supplements/glory-of-the-giants/backgrounds/background-rune-carver.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="background-rune-carver.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/glory-of-the-giants/backgrounds/background-rune-carver.xml" />
 		</update>
 	</info>
@@ -66,7 +66,7 @@
 			</select>
 		</rules>
 	</element>
-	<element name="Feature: Rune Shaper" type="Background Feature" source="Eberron: Rising from the Last War" id="ID_WOTC_GOTG_BACKGROUND_FEATURE_RUNE_CARVER_RUNE_SHAPER">
+	<element name="Feature: Rune Shaper" type="Background Feature" source="Bigby Presents: Glory of the Giants" id="ID_WOTC_GOTG_BACKGROUND_FEATURE_RUNE_CARVER_RUNE_SHAPER">
 		<supports>Background Feature</supports>
 		<description>
 			<p>You gain the Rune Shaper feat.</p>


### PR DESCRIPTION
Both of the background features had their sources mislabeled as "Eberron: Rising from the Last War"