### PR TITLE
[MISC] fixed typos in xml tag names

### DIFF
--- a/core/players-handbook/archetypes/druid-land.xml
+++ b/core/players-handbook/archetypes/druid-land.xml
@@ -87,7 +87,7 @@
 			<p class="indent">The creature is aware of this effect before it makes its attack against you.</p>
 		</description>
 		<sheet>
-			<descr>When a beast or plant creature attacks you, that creature must make a Wisdom saving throw. On a failed save, the creature must choose a different target, or the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours. The creature is aware of this effect before it makes its attack against you.</descr>
+			<description>When a beast or plant creature attacks you, that creature must make a Wisdom saving throw. On a failed save, the creature must choose a different target, or the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours. The creature is aware of this effect before it makes its attack against you.</description>
 		</sheet>
 	</element>
 

--- a/core/players-handbook/items/items-packs.xml
+++ b/core/players-handbook/items/items-packs.xml
@@ -149,7 +149,6 @@
 			<set name="weight" lb="10">10 lbs.</set>
 		</setters>
 		<extract>
-			<description>Includes a backpack, a book of lore, a bottle of ink, an ink pen, 10 sheets of parchment, a little bag of sand, and a small knife.</description>
 			<item>ID_WOTC_PHB_ITEM_BACKPACK</item>
 			<item>ID_WOTC_PHB_ITEM_BOOK</item>
 			<item>ID_WOTC_PHB_ITEM_INK_1OUNCEBOTTLE</item>

--- a/supplements/eberron-rising-from-the-last-war/items.xml
+++ b/supplements/eberron-rising-from-the-last-war/items.xml
@@ -841,9 +841,9 @@
 		</rules>
 	</append>
 	<append id="ID_PROFICIENCY_SKILL_SLEIGHTOFHAND">
-		<supports>Eberron Living Gloves Proficiency</supports>>
+		<supports>Eberron Living Gloves Proficiency</supports>
 	</append>
 	<append id="ID_PROFICIENCY_TOOL_PROFICIENCY_THIEVES_TOOLS">
-		<supports>Eberron Living Gloves Proficiency</supports>>
+		<supports>Eberron Living Gloves Proficiency</supports>
 	</append>
 </elements>

--- a/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
@@ -21,7 +21,7 @@
 
 	<element name="Path of the Battlerager" type="Archetype" source="Sword Coast Adventurer’s Guide" id="ID_WOTC_SCAG_ARCHETYPE_PATH_OF_THE_BATTLERAGER">
 		<supports>Primal Path</supports>
-		<prerequisites>Dwarf</prerequisites>
+		<prerequisite>Dwarf</prerequisite>
 		<requirements>ID_SRD_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
 		<description>
 			<p>Known as <i>Kuldjargh</i> (literally "axe idiot") in Dwarvish, battleragers are dwarf followers of the gods of war and take the Path of the Battlerager. They specialize in wearing bulky, spiked armor and throwing themselves into combat, striking with their body itself and giving themselves over to the fury of battle.</p>

--- a/unearthed-arcana/2018/20180108.xml
+++ b/unearthed-arcana/2018/20180108.xml
@@ -251,7 +251,7 @@
 			<p>At 2nd level, you gain proficiency with two tools of your choice.</p>
 		</description>
 		<sheet display="false">
-			<p>You gain proficiency with two tools of your choice.</p>
+			<description>You gain proficiency with two tools of your choice.</description>
 		</sheet>
 		<rules>
 			<select type="Proficiency" name="Tool Proficiency" supports="Tool" number="2"/>

--- a/unearthed-arcana/2019/20190228.xml
+++ b/unearthed-arcana/2019/20190228.xml
@@ -525,9 +525,9 @@
 		<description>
 			<p>Ranged Weapon Attack: +4 to hit, range 30 ft., one target you can see. Hit: 1d6 + 2 acid damage.</p>
 		</description>
-		<setter>
+		<setters>
 			<set name="action">Bonus Action</set>
-		</setter>
+		</setters>
 		<sheet>
 			<description>Ranged Weapon Attack: +4 to hit, range 30 ft., one target you can see. Hit: 1d6 + 2 acid damage.</description>
 		</sheet>
@@ -547,9 +547,9 @@
 				<li><strong>Resilience.</strong> The target gains a number of temporary hit points equal to 2d6 + your Intelligence modifier. </li>
 			</ul>
 		</description>
-		<setter>
+		<setters>
 			<set name="action">Bonus Action</set>
-		</setter>
+		</setters>
 		<sheet>
 			<description>The homunculus produces a salve and touches one creature you designate. The target receives one of the following magical benefits of your choice:
 			Buoyancy. The target gains a flying speed of 10 feet for 10 minutes.

--- a/unearthed-arcana/2019/20190514.xml
+++ b/unearthed-arcana/2019/20190514.xml
@@ -443,9 +443,9 @@
 		<description>
 			<p>Melee Weapon Attack: +4 to hit, reach 5 ft., one target you can see. Hit: 1d8 + 2 piercing damage.</p>
 		</description>
-		<setter>
+		<setters>
 			<set name="action">Bonus Action</set>
-		</setter>
+		</setters>
 		<sheet>
 			<description>Melee Weapon Attack: +4 to hit, reach 5 ft., one target you can see. Hit: 1d8 + 2 piercing damage.</description>
 		</sheet>
@@ -454,9 +454,9 @@
 		<description>
 			<p>The magical mechanisms inside the iron defender restore 2d8 + 2 hit points to itself or to one construct or object within 5 feet of it.</p>
 		</description>
-		<setter>
+		<setters>
 			<set name="action">Bonus Action</set>
-		</setter>
+		</setters>
 		<sheet usage="3/Day">
 			<description>The magical mechanisms inside the iron defender restore 2d8 + 2 hit points to itself or to one construct or object within 5 feet of it.</description>
 		</sheet>
@@ -466,9 +466,9 @@
 		<description>
 			<p>The iron defender imposes disadvantage on the attack roll of one creature it can see that is within 5 feet of it, provided the attack roll is against a creature other than the iron defender.</p>
 		</description>
-		<setter>
+		<setters>
 			<set name="action">Bonus Action</set>
-		</setter>
+		</setters>
 		<sheet>
 			<description>The iron defender imposes disadvantage on the attack roll of one creature it can see that is within 5 feet of it, provided the attack roll is against a creature other than the iron defender.</description>
 		</sheet>


### PR DESCRIPTION
I tried using the files with an xml binding library and these typos in the xml markup stood out there. I don't know if it actually matters to this project or the aurorabuilder, but I find it nice to to have consistency in the files. 