### PR TITLE
[DMG] Fixed typos in description for Truth Serum 

### DIFF
--- a/core/dungeon-masters-guide/items/items-poison.xml
+++ b/core/dungeon-masters-guide/items/items-poison.xml
@@ -59,7 +59,7 @@
 	</element>
 	<element name="Drow Poison" type="Item" source="Dungeon Master’s Guide" id="ID_WOTC_DMG_ITEM_POISON_DROW_POISON">
 		<description>
-			<p>This poison is typically made only by the draw, and only in a place far removed from sunlight. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the creature is also unconscious while poisoned in this way. The creature wakes up if it takes damage or if another creature takes an action to shake it awake.</p>
+			<p>This poison is typically made only by the drow, and only in a place far removed from sunlight. A creature subjected to this poison must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the creature is also unconscious while poisoned in this way. The creature wakes up if it takes damage or if another creature takes an action to shake it awake.</p>
 			<div class="reference">
 				<div element="ID_INTERNAL_SUPPORT_POISON_INJURY" />
 			</div>

--- a/core/dungeon-masters-guide/items/items-poison.xml
+++ b/core/dungeon-masters-guide/items/items-poison.xml
@@ -4,7 +4,7 @@
 		<name>Poison</name>
 		<description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.0.2">
+		<update version="0.0.3">
 			<file name="items-poison.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/dungeon-masters-guide/items/items-poison.xml" />
 		</update>
 	</info>

--- a/core/dungeon-masters-guide/items/items-poison.xml
+++ b/core/dungeon-masters-guide/items/items-poison.xml
@@ -203,7 +203,7 @@
 	</element>
 	<element name="Truth Serum" type="Item" source="Dungeon Master’s Guide" id="ID_WOTC_DMG_ITEM_POISON_TRUTH_SERUM">
 		<description>
-			<p>creature subjected to thi poison must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. The poisoned creature can't knowingly speak a lie, as if under the effect of a zone of truth spell.</p>
+			<p>A creature subjected to this poison must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. The poisoned creature can't knowingly speak a lie, as if under the effect of a zone of truth spell.</p>
 			<div class="reference">
 				<div element="ID_INTERNAL_SUPPORT_POISON_INGESTED" />
 			</div>


### PR DESCRIPTION
Update DMG items-poison.xml
A couple of letters were missing. 