### PR TITLE
[TCOE] Typos and Fixes

### DIFF
--- a/supplements/tashas-cauldron-of-everything/artificer-infusions.xml
+++ b/supplements/tashas-cauldron-of-everything/artificer-infusions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.5">
+		<update version="0.0.7">
 			<file name="artificer-infusions.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/artificer-infusions.xml" />
 		</update>
 	</info>
@@ -209,7 +209,7 @@
 	</element>
 	<element name="Mind Sharpener Robe" type="Magic Item" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_MAGIC_ITEM_MIND_SHARPENER">
 		<description>
-			<p>The infused item can send a jolt to the wearer to refocus their mind. The item has 4 charges. When the wearer fails a Constitution saving throw to maintain concentration on a spell, the wearer can use its reaction to expend 1 of the item's charges to succeed instead. The item regains ld4 expended charges daily at dawn.</p>
+			<p>The infused item can send a jolt to the wearer to refocus their mind. The item has 4 charges. When the wearer fails a Constitution saving throw to maintain concentration on a spell, the wearer can use its reaction to expend 1 of the item's charges to succeed instead. The item regains 1d4 expended charges daily at dawn.</p>
 		</description>
 		<setters>
 			<set name="category">Wondrous Items</set>

--- a/supplements/tashas-cauldron-of-everything/artificer-infusions.xml
+++ b/supplements/tashas-cauldron-of-everything/artificer-infusions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.7">
+		<update version="0.0.6">
 			<file name="artificer-infusions.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/artificer-infusions.xml" />
 		</update>
 	</info>

--- a/supplements/tashas-cauldron-of-everything/class-artificer.xml
+++ b/supplements/tashas-cauldron-of-everything/class-artificer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="class-artificer.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/class-artificer.xml" />
 		</update>
 	</info>
@@ -53,7 +53,7 @@
 				<tr><td> 1st</td><td class="left">Magical Tinkering, Spellcasting</td><td> —</td><td>—</td><td>2</td><td>2</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 2nd</td><td class="left">Infuse Item</td><td> 4</td><td>2</td><td>2</td><td>2</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 3rd</td><td class="left">Artificer Specialist, The Right Tool for the Job</td><td> 4</td><td>2</td><td>2</td><td>3</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
-				<tr><td> 4th</td><td class="left">Ability Score Improvement</td><td> 4</td><td>2</td><td>2</td><td>4</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
+				<tr><td> 4th</td><td class="left">Ability Score Improvement</td><td> 4</td><td>2</td><td>2</td><td>3</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 5th</td><td class="left">Artificer Specialist feature</td><td> 4</td><td>2</td><td>2</td><td>4</td><td>2</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 6th</td><td class="left">Tool Expertise</td><td> 6</td><td>3</td><td>2</td><td>4</td><td>2</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 7th</td><td class="left">Flash of Genius</td><td> 6</td><td>3</td><td>2</td><td>4</td><td>3</td><td>—</td><td>—</td><td>—</td></tr>

--- a/supplements/tashas-cauldron-of-everything/class-artificer.xml
+++ b/supplements/tashas-cauldron-of-everything/class-artificer.xml
@@ -73,7 +73,6 @@
 			</table>
 			<div class="sidebar">
 				<h5>OPTIONAL RULE: FIREARM PROFICIENCY</h5>
-				<p><b>Note:</b> This feat requires Firearms Character Option to be enabled.</p>
 				<p>The secrets of creating and operating gunpowder weapons have been discovered in various corners of the D&amp;D multiverse. If your Dungeon Master uses the rules on firearms in chapter 9 of the Dungeon Master’s Guide and your artificer has been exposed to the operation of such weapons, your artificer is proficient with them.</p>
 			</div>
 			<div element="ID_WOTC_TCOE_CLASS_FEATURE_ARTIFICER_MAGICAL_TINKERING" />

--- a/supplements/tashas-cauldron-of-everything/class-artificer.xml
+++ b/supplements/tashas-cauldron-of-everything/class-artificer.xml
@@ -73,6 +73,7 @@
 			</table>
 			<div class="sidebar">
 				<h5>OPTIONAL RULE: FIREARM PROFICIENCY</h5>
+				<p><b>Note:</b> This feat requires Firearms Character Option to be enabled.</p>
 				<p>The secrets of creating and operating gunpowder weapons have been discovered in various corners of the D&amp;D multiverse. If your Dungeon Master uses the rules on firearms in chapter 9 of the Dungeon Master’s Guide and your artificer has been exposed to the operation of such weapons, your artificer is proficient with them.</p>
 			</div>
 			<div element="ID_WOTC_TCOE_CLASS_FEATURE_ARTIFICER_MAGICAL_TINKERING" />

--- a/supplements/tashas-cauldron-of-everything/feats.xml
+++ b/supplements/tashas-cauldron-of-everything/feats.xml
@@ -219,7 +219,8 @@
 	</element>
 
 	<element name="Gunner" type="Feat" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_FEAT_GUNNER">
-		<description>
+		<description><p>
+			<b>Note:</b> This feat requires Firearms Character Option to be enabled.</p>
 			<p>You have a quick hand and keen eye when employing firearms, granting you the following benefits:</p>
 			<ul>
 				<li>Increase your Dexterity score by 1, to a maximum of 20.</li>

--- a/supplements/tashas-cauldron-of-everything/feats.xml
+++ b/supplements/tashas-cauldron-of-everything/feats.xml
@@ -4,7 +4,7 @@
 		<name>Feats</name>
 		<description>The Feats from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.6">
+		<update version="0.0.7">
 			<file name="feats.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/feats.xml" />
 		</update>
 	</info>
@@ -60,7 +60,7 @@
 			</ul>
 		</description>
 		<sheet>
-			<description>Once per turn, when you hit a creature with an attack that deals bludgeoning damage, you can move it 5 feet to an unoccupied space, provided the target is no more than one size larger than you. When you score a critical hit that deals bludgeoning damage to a creature, attack rolls against that creature are made with advantage until the end of your next turn.</description>
+			<description>Once per turn, when you hit a creature with an attack that deals bludgeoning damage, you can move it 5 feet to an unoccupied space, provided the target is no more than one size larger than you. When you score a critical hit that deals bludgeoning damage to a creature, attack rolls against that creature are made with advantage until the start of your next turn.</description>
 		</sheet>
 		<rules>
 			<select type="Ability Score Improvement" name="Ability Score Increase (Crusher)" supports="ID_PHB_FEAT_ASI_STRENGTH|ID_PHB_FEAT_ASI_CONSTITUTION" />			

--- a/supplements/tashas-cauldron-of-everything/feats.xml
+++ b/supplements/tashas-cauldron-of-everything/feats.xml
@@ -219,8 +219,8 @@
 	</element>
 
 	<element name="Gunner" type="Feat" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_FEAT_GUNNER">
-		<description><p>
-			<b>Note:</b> This feat requires Firearms Character Option to be enabled.</p>
+		<description>
+			<p><b>Note:</b> This feat requires Firearms Character Option to be enabled.</p>
 			<p>You have a quick hand and keen eye when employing firearms, granting you the following benefits:</p>
 			<ul>
 				<li>Increase your Dexterity score by 1, to a maximum of 20.</li>

--- a/supplements/tashas-cauldron-of-everything/optional-class-features.xml
+++ b/supplements/tashas-cauldron-of-everything/optional-class-features.xml
@@ -4,7 +4,7 @@
 		<name>Optional Class Features</name>
 		<description>The Optional Class Features from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.8">
+		<update version="0.0.9">
 			<file name="optional-class-features.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/optional-class-features.xml" />
 		</update>
 	</info>
@@ -796,7 +796,7 @@
 	<!-- Martial Versatility -->
 	<element name="Martial Versatility (Paladin)" type="Class Feature" source="Tasha’s Cauldron of Everything" id="ID_WOTC_TCOE_CLASS_FEATURE_PALADIN_MARTIAL_VERSATILITY">
 		<description>
-			<p><i>4th-level ranger feature</i></p>
+			<p><i>4th-level paladin feature</i></p>
 			<p>Whenever you reach a level in this class that grants the Ability Score Improvement feature, you can replace a fighting style you know with another fighting style available to paladins. This replacement represents a shift of focus in your martial practice.</p>
 		</description>
 		<sheet alt="Martial Versatility">

--- a/supplements/tashas-cauldron-of-everything/spells.xml
+++ b/supplements/tashas-cauldron-of-everything/spells.xml
@@ -4,7 +4,7 @@
 		<name>Spells</name>
 		<description>The Spells Arcane Tradition from Tasha’s Cauldron of Everything</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/tashas-cauldron-everything">Tasha’s Cauldron of Everything</author>
-		<update version="0.0.5">
+		<update version="0.0.6">
 			<file name="spells.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/tashas-cauldron-of-everything/spells.xml" />
 		</update>
 	</info>
@@ -39,8 +39,8 @@
 			<set name="school">Evocation</set>
 			<set name="time">1 action</set>
 			<set name="range">Self (5-foot radius)</set>
-			<set name="hasVerbalComponent">true</set>
-			<set name="hasSomaticComponent">false</set>
+			<set name="hasVerbalComponent">false</set>
+			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
 			<set name="materialComponent">a melee weapon worth at least 1 sp</set>
 			<set name="duration">1 round</set>
@@ -76,8 +76,8 @@
 			<set name="school">Evocation</set>
 			<set name="time">1 action</set>
 			<set name="range">Self (5-foot radius)</set>
-			<set name="hasVerbalComponent">true</set>
-			<set name="hasSomaticComponent">false</set>
+			<set name="hasVerbalComponent">false</set>
+			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
 			<set name="materialComponent">a melee weapon worth at least 1 sp</set>
 			<set name="duration">Instantaneous</set>


### PR DESCRIPTION
Fixed Crusher feat sheet typo, end of turn to start of turn
Fixed Booming Blade and Green-Flame Blade component bools, verbal to somatic
Fixed Artificer class table having the wrong spell slot count on 4th level
Fixed Mind Sharpener Robe copy-paste error, ld4 to 1d4
Fixed Martial Versatility (Paladin) copy-paste error, Ranger to paladin

Should I add in [Artificer Infusion Bug](https://github.com/AuroraLegacy/elements/issues/228#issue-2052931478) fix?