### PR TITLE
[ERLW] Fixed Artificer typos

### DIFF
--- a/supplements/eberron-rising-from-the-last-war/artificer-infusions.xml
+++ b/supplements/eberron-rising-from-the-last-war/artificer-infusions.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name>Artificer Infusions</name>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="artificer-infusions.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/eberron-rising-from-the-last-war/artificer-infusions.xml" />
 		</update>
 	</info>
@@ -381,7 +381,7 @@
 				<tr><td>Helm of telepathy</td><td>Yes</td></tr>
 				<tr><td>Medallion of thoughts</td><td>Yes</td></tr>
 				<tr><td>Necklace of adaptation</td><td>Yes</td></tr>
-				<tr><td>Peria pt of wound closure</td><td>Yes</td></tr>
+				<tr><td>Periapt of wound closure</td><td>Yes</td></tr>
 				<tr><td>Pipes of the sewers</td><td>Yes</td></tr>
 				<tr><td>Quiver of Ehlonna</td><td>No</td></tr>
 				<tr><td>Ring of jumping</td><td>Yes</td></tr>

--- a/supplements/eberron-rising-from-the-last-war/class-artificer.xml
+++ b/supplements/eberron-rising-from-the-last-war/class-artificer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<update version="0.1.3">
+		<update version="0.1.4">
 			<file name="class-artificer.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/eberron-rising-from-the-last-war/class-artificer.xml" />
 		</update>
 	</info>
@@ -54,7 +54,7 @@
 				<tr><td> 1st</td><td class="left">Magical Tinkering, Spellcasting</td><td> —</td><td>—</td><td>2</td><td>2</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 2nd</td><td class="left">Infuse Item</td><td> 4</td><td>2</td><td>2</td><td>2</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 3rd</td><td class="left">Artificer Specialist, The Right Tool for the Job</td><td> 4</td><td>2</td><td>2</td><td>3</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
-				<tr><td> 4th</td><td class="left">Ability Score Improvement</td><td> 4</td><td>2</td><td>2</td><td>4</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
+				<tr><td> 4th</td><td class="left">Ability Score Improvement</td><td> 4</td><td>2</td><td>2</td><td>3</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 5th</td><td class="left">Artificer Specialist feature</td><td> 4</td><td>2</td><td>2</td><td>4</td><td>2</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 6th</td><td class="left">Tool Expertise</td><td> 6</td><td>3</td><td>2</td><td>4</td><td>2</td><td>—</td><td>—</td><td>—</td></tr>
 				<tr><td> 7th</td><td class="left">Flash of Genius</td><td> 6</td><td>3</td><td>2</td><td>4</td><td>3</td><td>—</td><td>—</td><td>—</td></tr>


### PR DESCRIPTION
Fixed Artificer class table level 4, 4 1st-level spell slots to 3
Fixed Artificer replicate magic item typo, peria pt to periapt

Should I add in [Artificer Infusion Bug](https://github.com/AuroraLegacy/elements/issues/228#issue-2052931478) fix?