### PR TITLE
[SCAG] Expanded requirements to include Deurgar and other dwarves

### DIFF
--- a/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
@@ -22,7 +22,7 @@
 	<element name="Path of the Battlerager" type="Archetype" source="Sword Coast Adventurer’s Guide" id="ID_WOTC_SCAG_ARCHETYPE_PATH_OF_THE_BATTLERAGER">
 		<supports>Primal Path</supports>
 		<prerequisites>Dwarf</prerequisites>
-		<requirements>ID_SRD_RACE_DWARF||ID_INTERNAL_RACIAL_TRAIT_TYPE_HUMANOID_DWARF||ID_INTERNAL_GRANT_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
+		<requirements>ID_SRD_RACE_DWARF||ID_INTERNAL_GRANT_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
 		<description>
 			<p>Known as <i>Kuldjargh</i> (literally "axe idiot") in Dwarvish, battleragers are dwarf followers of the gods of war and take the Path of the Battlerager. They specialize in wearing bulky, spiked armor and throwing themselves into combat, striking with their body itself and giving themselves over to the fury of battle.</p>
 			<div class="sidebar">

--- a/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
@@ -4,7 +4,7 @@
 		<name>Path of the Battlerager</name>
 		<description>The Path of the Battlerager archetype from the Sword Coast Adventurer’s Guide.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/sc-adventurers-guide">Wizards of the Coast</author>
-		<update version="0.0.7">
+		<update version="0.0.8">
 			<file name="barbarian-battlerager.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml" />
 		</update>
 	</info>
@@ -22,7 +22,7 @@
 	<element name="Path of the Battlerager" type="Archetype" source="Sword Coast Adventurer’s Guide" id="ID_WOTC_SCAG_ARCHETYPE_PATH_OF_THE_BATTLERAGER">
 		<supports>Primal Path</supports>
 		<prerequisites>Dwarf</prerequisites>
-		<requirements>ID_SRD_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
+		<requirements>ID_SRD_RACE_DWARF||ID_INTERNAL_RACIAL_TRAIT_TYPE_HUMANOID_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
 		<description>
 			<p>Known as <i>Kuldjargh</i> (literally "axe idiot") in Dwarvish, battleragers are dwarf followers of the gods of war and take the Path of the Battlerager. They specialize in wearing bulky, spiked armor and throwing themselves into combat, striking with their body itself and giving themselves over to the fury of battle.</p>
 			<div class="sidebar">

--- a/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
@@ -22,7 +22,7 @@
 	<element name="Path of the Battlerager" type="Archetype" source="Sword Coast Adventurer’s Guide" id="ID_WOTC_SCAG_ARCHETYPE_PATH_OF_THE_BATTLERAGER">
 		<supports>Primal Path</supports>
 		<prerequisites>Dwarf</prerequisites>
-		<requirements>ID_SRD_RACE_DWARF||ID_INTERNAL_RACIAL_TRAIT_TYPE_HUMANOID_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
+		<requirements>ID_SRD_RACE_DWARF||ID_INTERNAL_RACIAL_TRAIT_TYPE_HUMANOID_DWARF||ID_INTERNAL_GRANT_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
 		<description>
 			<p>Known as <i>Kuldjargh</i> (literally "axe idiot") in Dwarvish, battleragers are dwarf followers of the gods of war and take the Path of the Battlerager. They specialize in wearing bulky, spiked armor and throwing themselves into combat, striking with their body itself and giving themselves over to the fury of battle.</p>
 			<div class="sidebar">

--- a/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
+++ b/supplements/sword-coast-adventurers-guide/classes/barbarian-battlerager.xml
@@ -21,8 +21,8 @@
 
 	<element name="Path of the Battlerager" type="Archetype" source="Sword Coast Adventurer’s Guide" id="ID_WOTC_SCAG_ARCHETYPE_PATH_OF_THE_BATTLERAGER">
 		<supports>Primal Path</supports>
-		<prerequisites>Dwarf</prerequisites>
-		<requirements>ID_SRD_RACE_DWARF||ID_INTERNAL_GRANT_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
+		<prerequisite>Dwarf</prerequisite>
+		<requirements>ID_INTERNAL_GRANT_RACE_DWARF||ID_WOTC_SCAG_OPTION_BATTLERAGER</requirements>
 		<description>
 			<p>Known as <i>Kuldjargh</i> (literally "axe idiot") in Dwarvish, battleragers are dwarf followers of the gods of war and take the Path of the Battlerager. They specialize in wearing bulky, spiked armor and throwing themselves into combat, striking with their body itself and giving themselves over to the fury of battle.</p>
 			<div class="sidebar">


### PR DESCRIPTION
Added ID_INTERNAL_RACIAL_TRAIT_TYPE_HUMANOID_DWARF to Battlerager requirements