### PR TITLE
[PHB24] Equipment Packs for Classes

### DIFF
--- a/core/players-handbook-2024/backgrounds/background-acolyte.xml
+++ b/core/players-handbook-2024/backgrounds/background-acolyte.xml
@@ -35,27 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_CALLIGRAPHERS_SUPPLIES" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Acolyte)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_ACOLYTE">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Acolyte Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Calligrapher’s Supplies</p>
-			<p class="indent">• Book (prayers)</p>
-			<p class="indent">• Parchment (10 sheets)</p>
-			<p class="indent" style="margin-bottom:5px">• Robe</p>
-			<p><b>Note:</b> This pack doesn't include Holy Symbol (can be chosen in "Spellcasting Focus" Equipment category) and 8 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_CALLIGRAPHERS_SUPPLIES</item>
-			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
-			<item amount="10">ID_WOTC_PHB24_ITEM_PARCHMENT</item>
-			<item>ID_WOTC_PHB24_ITEM_ROBE</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-artisan.xml
+++ b/core/players-handbook-2024/backgrounds/background-artisan.xml
@@ -35,23 +35,4 @@
 			<select type="Proficiency" name="Tool Proficiency (Artisan)" supports="Tool, Artisan tools" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Artisan)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_ARTISAN">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Artisan Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• 2 Pouches</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include the Artisan’s Tools of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 32 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-charlatan.xml
+++ b/core/players-handbook-2024/backgrounds/background-charlatan.xml
@@ -35,25 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_FORGERY_KIT" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Charlatan)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_CHARLATAN">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Charlatan Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Forgery Kit</p>
-			<p class="indent">• Costume</p>
-			<p class="indent">• Fine Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 15 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_FORGERY_KIT</item>
-			<item>ID_WOTC_PHB24_ITEM_COSTUME</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_FINE</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-criminal.xml
+++ b/core/players-handbook-2024/backgrounds/background-criminal.xml
@@ -35,29 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_THIEVES_TOOLS" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Criminal)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_CRIMINAL">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Criminal Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• 2 Daggers</p>
-			<p class="indent">• Thieves' Tools</p>
-			<p class="indent">• Crowbar</p>
-			<p class="indent">• 2 Pouches</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 15 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_THIEVES_TOOLS</item>
-			<item>ID_WOTC_PHB24_ITEM_CROWBAR</item>
-			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-entertainer.xml
+++ b/core/players-handbook-2024/backgrounds/background-entertainer.xml
@@ -35,27 +35,4 @@
 			<select type="Proficiency" name="Musical Instrument (Entertainer)" supports="Musical Instrument" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Entertainer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_ENTERTAINER">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Entertainer Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• 2 Costumes</p>
-			<p class="indent">• Mirror</p>
-			<p class="indent">• Perfume</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include the Musical Instrument of the same kind as Proficiency gained from this Background (can be taken from "Musical Instruments" Equipment category) and 11 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item amount="2">ID_WOTC_PHB24_ITEM_COSTUME</item>
-			<item>ID_WOTC_PHB24_ITEM_MIRROR</item>
-			<item>ID_WOTC_PHB24_ITEM_PERFUME</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-farmer.xml
+++ b/core/players-handbook-2024/backgrounds/background-farmer.xml
@@ -35,31 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_CARPENTERS_TOOLS" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Farmer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_FARMER">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Farmer Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Sickle</p>
-			<p class="indent">• Carpenter's Tools</p>
-			<p class="indent">• Healer's Kit</p>
-			<p class="indent">• Iron Pot</p>
-			<p class="indent">• Shovel</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 30 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_SICKLE</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_CARPENTERS_TOOLS</item>
-			<item>ID_WOTC_PHB24_ITEM_HEALERS_KIT</item>
-			<item>ID_WOTC_PHB24_ITEM_POT_IRON</item>
-			<item>ID_WOTC_PHB24_ITEM_SHOVEL</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-guard.xml
+++ b/core/players-handbook-2024/backgrounds/background-guard.xml
@@ -35,33 +35,4 @@
 			<select type="Proficiency" name="Gaming Set (Guard)" supports="Gaming Set" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Guard)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_GUARD">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Guard Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Spear</p>
-			<p class="indent">• Light Crossbow</p>
-			<p class="indent">• 20 Bolts</p>
-			<p class="indent">• Hooded Lantern</p>
-			<p class="indent">• Manacles</p>
-			<p class="indent">• Quiver</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 12 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_SPEAR</item>
-			<item>ID_WOTC_PHB24_WEAPON_CROSSBOW_LIGHT</item>
-			<item amount="20">ID_WOTC_PHB24_ITEM_BOLT</item>
-			<item>ID_WOTC_PHB24_ITEM_LANTERN_HOODED</item>
-			<item>ID_WOTC_PHB24_ITEM_MANACLES</item>
-			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-guide.xml
+++ b/core/players-handbook-2024/backgrounds/background-guide.xml
@@ -35,33 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_CARTOGRAPHERS_TOOLS" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Guide)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_GUIDE">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Guide Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Shortbow</p>
-			<p class="indent">• 20 Arrows</p>
-			<p class="indent">• Cartographer's Tools</p>
-			<p class="indent">• Bedroll</p>
-			<p class="indent">• Quiver</p>
-			<p class="indent">• Tent</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 3 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_SHORTBOW</item>
-			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_CARTOGRAPHERS_TOOLS</item>
-			<item>ID_WOTC_PHB24_ITEM_BEDROLL</item>
-			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
-			<item>ID_WOTC_PHB24_ITEM_TENT</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-hermit.xml
+++ b/core/players-handbook-2024/backgrounds/background-hermit.xml
@@ -35,33 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_HERBALISM_KIT" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Hermit)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_HERMIT">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Hermit Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Quarterstaff</p>
-			<p class="indent">• Herbalism Kit</p>
-			<p class="indent">• Bedroll</p>
-			<p class="indent">• Book (philosophy)</p>
-			<p class="indent">• Lamp</p>
-			<p class="indent">• Oil (3 flasks)</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 16 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_QUARTERSTAFF</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_HERBALISM_KIT</item>
-			<item>ID_WOTC_PHB24_ITEM_BEDROLL</item>
-			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
-			<item>ID_WOTC_PHB24_ITEM_LAMP</item>
-			<item amount="3">ID_WOTC_PHB24_ITEM_OIL</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-merchant.xml
+++ b/core/players-handbook-2024/backgrounds/background-merchant.xml
@@ -35,25 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_NAVIGATORS_TOOLS" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Merchant)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_MERCHANT">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Merchant Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Navigator's Tools</p>
-			<p class="indent">• 2 Pouches</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 22 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_NAVIGATORS_TOOLS</item>
-			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-noble.xml
+++ b/core/players-handbook-2024/backgrounds/background-noble.xml
@@ -35,23 +35,4 @@
 			<select type="Proficiency" name="Gaming Set (Noble)" supports="Gaming Set" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Noble)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_NOBLE">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Noble Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Fine Clothes</p>
-			<p class="indent">• Perfume</p>
-			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 29 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_FINE</item>
-			<item>ID_WOTC_PHB24_ITEM_PERFUME</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-sage.xml
+++ b/core/players-handbook-2024/backgrounds/background-sage.xml
@@ -35,29 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_CALLIGRAPHERS_SUPPLIES" />	
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Sage)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SAGE">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Sage Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Quarterstaff</p>
-			<p class="indent">• Calligrapher's Supplies</p>
-			<p class="indent">• Book (history)</p>
-			<p class="indent">• Parchment (8 sheets)</p>
-			<p class="indent">• Robe</p>
-			<p><b>Note:</b> This pack doesn't include 8 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_QUARTERSTAFF</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_CALLIGRAPHERS_SUPPLIES</item>
-			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
-			<item amount="8">ID_WOTC_PHB24_ITEM_PARCHMENT</item>
-			<item>ID_WOTC_PHB24_ITEM_ROBE</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-sailor.xml
+++ b/core/players-handbook-2024/backgrounds/background-sailor.xml
@@ -35,27 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_NAVIGATORS_TOOLS" />	
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Sailor)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SAILOR">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Sailor Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Dagger</p>
-			<p class="indent">• Navigator's Tools</p>
-			<p class="indent">• Rope</p>
-			<p class="indent">• Traveler’s Clothes</p>
-			<p><b>Note:</b> This pack doesn't include 20 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_DAGGER</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_NAVIGATORS_TOOLS</item>
-			<item>ID_WOTC_PHB24_ITEM_ROPE</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-scribe.xml
+++ b/core/players-handbook-2024/backgrounds/background-scribe.xml
@@ -35,29 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_CALLIGRAPHERS_SUPPLIES" />	
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Scribe)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SCRIBE">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Scribe Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Calligrapher's Supplies</p>
-			<p class="indent">• Fine Clothes</p>
-			<p class="indent">• Lamp</p>
-			<p class="indent">• Oil (3 flasks)</p>
-			<p class="indent">• Parchment (12 sheets)</p>
-			<p><b>Note:</b> This pack doesn't include 23 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_CALLIGRAPHERS_SUPPLIES</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_FINE</item>
-			<item>ID_WOTC_PHB24_ITEM_LAMP</item>
-			<item amount="3">ID_WOTC_PHB24_ITEM_OIL</item>
-			<item amount="12">ID_WOTC_PHB24_ITEM_PARCHMENT</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-soldier.xml
+++ b/core/players-handbook-2024/backgrounds/background-soldier.xml
@@ -35,31 +35,4 @@
 			<select type="Proficiency" name="Gaming Set (Soldier)" supports="Gaming Set" />
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Soldier)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SOLDIER">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Soldier Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• Spear</p>
-			<p class="indent">• Shortbow</p>
-			<p class="indent">• 20 Arrows</p>
-			<p class="indent">• Healer's Kit</p>
-			<p class="indent">• Quiver</p>
-			<p class="indent">• Traveler’s Clothes</p>
-			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 14 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item>ID_WOTC_PHB24_WEAPON_SPEAR</item>
-			<item>ID_WOTC_PHB24_WEAPON_SHORTBOW</item>
-			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
-			<item>ID_WOTC_PHB24_ITEM_HEALERS_KIT</item>
-			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/backgrounds/background-wayfarer.xml
+++ b/core/players-handbook-2024/backgrounds/background-wayfarer.xml
@@ -35,29 +35,4 @@
 			<grant type="Proficiency" id="ID_PROFICIENCY_TOOL_PROFICIENCY_THIEVES_TOOLS" />	
 		</rules>
 	</element>
-
-	<element name="Background Equipment Pack (Wayfarer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_WAYFARER">
-		<description>
-			<p style="margin-bottom:5px">This pack contains items that are given to a character of Wayfarer Background, if you chose option A for Equipment.</p>
-			<p>You will receive following items by extracting contents of this pack:</p>
-			<p class="indent">• 2 Daggers</p>
-			<p class="indent">• Thieves' Tools</p>
-			<p class="indent">• Bedroll</p>
-			<p class="indent">• 2 Pouches</p>
-			<p class="indent">• Traveler's Clothes</p>
-			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 16 GP.</p>
-		</description>
-		<setters>
-			<set name="category">Equipment Packs</set>
-			<set name="cost">—</set>
-			<set name="weight">—</set>
-		</setters>
-		<extract>
-			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
-			<item>ID_WOTC_PHB24_ITEM_TOOL_THIEVES_TOOLS</item>
-			<item>ID_WOTC_PHB24_ITEM_BEDROLL</item>
-			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
-			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
-		</extract>
-	</element>
 </elements>

--- a/core/players-handbook-2024/classes/class-rogue.xml
+++ b/core/players-handbook-2024/classes/class-rogue.xml
@@ -428,7 +428,6 @@
 		</sheet>
 	</element>
 
-
 	<!--Feature Replacement Grants-->
 	<element name="Expertise Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_PHB24_FEATURE_REPLACEMENT_ROGUE_EXPERTISE" />
 	<element name="Sneak Attack Feature Replacement" type="Grants" source="Internal" id="ID_INTERNAL_PHB24_FEATURE_REPLACEMENT_ROGUE_SNEAK_ATTACK" />

--- a/core/players-handbook-2024/items/items-armor.xml
+++ b/core/players-handbook-2024/items/items-armor.xml
@@ -267,7 +267,7 @@
 		</rules>
 	</element>
 
-	<element name="Shield" type="Armor" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_GEAR_SHIELD">
+	<element name="Shield" type="Armor" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ARMOR_SHIELD">
 		<supports>ID_INTERNAL_ARMOR_GROUP_SHIELD</supports>
 		<description>
 			<p>A shield is made from wood or metal and is carried in one hand. Wielding a shield increases your Armor Class by 2. You can benefit from only one shield at a time.</p>

--- a/core/players-handbook-2024/items/items-packs.xml
+++ b/core/players-handbook-2024/items/items-packs.xml
@@ -8,6 +8,703 @@
 		</update>
 	</info>
 
+	<!-- Background Equipment Packs -->
+	<element name="Background Equipment Pack (Acolyte)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_ACOLYTE">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Acolyte Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Calligrapher’s Supplies</p>
+			<p class="indent">• Book (prayers)</p>
+			<p class="indent">• Parchment (10 sheets)</p>
+			<p class="indent" style="margin-bottom:5px">• Robe</p>
+			<p><b>Note:</b> This pack doesn't include Holy Symbol (can be chosen in "Spellcasting Focus" Equipment category) and 8 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_CALLIGRAPHERS_SUPPLIES</item>
+			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
+			<item amount="10">ID_WOTC_PHB24_ITEM_PARCHMENT</item>
+			<item>ID_WOTC_PHB24_ITEM_ROBE</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Artisan)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_ARTISAN">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Artisan Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Pouches</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include the Artisan’s Tools of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 32 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Charlatan)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_CHARLATAN">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Charlatan Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Forgery Kit</p>
+			<p class="indent">• Costume</p>
+			<p class="indent">• Fine Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 15 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_FORGERY_KIT</item>
+			<item>ID_WOTC_PHB24_ITEM_COSTUME</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_FINE</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Criminal)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_CRIMINAL">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Criminal Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent">• Thieves' Tools</p>
+			<p class="indent">• Crowbar</p>
+			<p class="indent">• 2 Pouches</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 15 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_THIEVES_TOOLS</item>
+			<item>ID_WOTC_PHB24_ITEM_CROWBAR</item>
+			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Entertainer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_ENTERTAINER">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Entertainer Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Costumes</p>
+			<p class="indent">• Mirror</p>
+			<p class="indent">• Perfume</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include the Musical Instrument of the same kind as Proficiency gained from this Background (can be taken from "Musical Instruments" Equipment category) and 11 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_ITEM_COSTUME</item>
+			<item>ID_WOTC_PHB24_ITEM_MIRROR</item>
+			<item>ID_WOTC_PHB24_ITEM_PERFUME</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Farmer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_FARMER">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Farmer Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Sickle</p>
+			<p class="indent">• Carpenter's Tools</p>
+			<p class="indent">• Healer's Kit</p>
+			<p class="indent">• Iron Pot</p>
+			<p class="indent">• Shovel</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 30 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SICKLE</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_CARPENTERS_TOOLS</item>
+			<item>ID_WOTC_PHB24_ITEM_HEALERS_KIT</item>
+			<item>ID_WOTC_PHB24_ITEM_POT_IRON</item>
+			<item>ID_WOTC_PHB24_ITEM_SHOVEL</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Guard)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_GUARD">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Guard Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Spear</p>
+			<p class="indent">• Light Crossbow</p>
+			<p class="indent">• 20 Bolts</p>
+			<p class="indent">• Hooded Lantern</p>
+			<p class="indent">• Manacles</p>
+			<p class="indent">• Quiver</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 12 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SPEAR</item>
+			<item>ID_WOTC_PHB24_WEAPON_CROSSBOW_LIGHT</item>
+			<item amount="20">ID_WOTC_PHB24_ITEM_BOLT</item>
+			<item>ID_WOTC_PHB24_ITEM_LANTERN_HOODED</item>
+			<item>ID_WOTC_PHB24_ITEM_MANACLES</item>
+			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Guide)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_GUIDE">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Guide Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Shortbow</p>
+			<p class="indent">• 20 Arrows</p>
+			<p class="indent">• Cartographer's Tools</p>
+			<p class="indent">• Bedroll</p>
+			<p class="indent">• Quiver</p>
+			<p class="indent">• Tent</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 3 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SHORTBOW</item>
+			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_CARTOGRAPHERS_TOOLS</item>
+			<item>ID_WOTC_PHB24_ITEM_BEDROLL</item>
+			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
+			<item>ID_WOTC_PHB24_ITEM_TENT</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Hermit)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_HERMIT">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Hermit Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Quarterstaff</p>
+			<p class="indent">• Herbalism Kit</p>
+			<p class="indent">• Bedroll</p>
+			<p class="indent">• Book (philosophy)</p>
+			<p class="indent">• Lamp</p>
+			<p class="indent">• Oil (3 flasks)</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 16 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_QUARTERSTAFF</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_HERBALISM_KIT</item>
+			<item>ID_WOTC_PHB24_ITEM_BEDROLL</item>
+			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
+			<item>ID_WOTC_PHB24_ITEM_LAMP</item>
+			<item amount="3">ID_WOTC_PHB24_ITEM_OIL</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Merchant)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_MERCHANT">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Merchant Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Navigator's Tools</p>
+			<p class="indent">• 2 Pouches</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 22 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_NAVIGATORS_TOOLS</item>
+			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Noble)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_NOBLE">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Noble Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Fine Clothes</p>
+			<p class="indent">• Perfume</p>
+			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 29 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_FINE</item>
+			<item>ID_WOTC_PHB24_ITEM_PERFUME</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Sage)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SAGE">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Sage Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Quarterstaff</p>
+			<p class="indent">• Calligrapher's Supplies</p>
+			<p class="indent">• Book (history)</p>
+			<p class="indent">• Parchment (8 sheets)</p>
+			<p class="indent">• Robe</p>
+			<p><b>Note:</b> This pack doesn't include 8 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_QUARTERSTAFF</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_CALLIGRAPHERS_SUPPLIES</item>
+			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
+			<item amount="8">ID_WOTC_PHB24_ITEM_PARCHMENT</item>
+			<item>ID_WOTC_PHB24_ITEM_ROBE</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Sailor)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SAILOR">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Sailor Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Dagger</p>
+			<p class="indent">• Navigator's Tools</p>
+			<p class="indent">• Rope</p>
+			<p class="indent">• Traveler’s Clothes</p>
+			<p><b>Note:</b> This pack doesn't include 20 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_NAVIGATORS_TOOLS</item>
+			<item>ID_WOTC_PHB24_ITEM_ROPE</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Scribe)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SCRIBE">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Scribe Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Calligrapher's Supplies</p>
+			<p class="indent">• Fine Clothes</p>
+			<p class="indent">• Lamp</p>
+			<p class="indent">• Oil (3 flasks)</p>
+			<p class="indent">• Parchment (12 sheets)</p>
+			<p><b>Note:</b> This pack doesn't include 23 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_CALLIGRAPHERS_SUPPLIES</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_FINE</item>
+			<item>ID_WOTC_PHB24_ITEM_LAMP</item>
+			<item amount="3">ID_WOTC_PHB24_ITEM_OIL</item>
+			<item amount="12">ID_WOTC_PHB24_ITEM_PARCHMENT</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Soldier)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_SOLDIER">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Soldier Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Spear</p>
+			<p class="indent">• Shortbow</p>
+			<p class="indent">• 20 Arrows</p>
+			<p class="indent">• Healer's Kit</p>
+			<p class="indent">• Quiver</p>
+			<p class="indent">• Traveler’s Clothes</p>
+			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 14 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SPEAR</item>
+			<item>ID_WOTC_PHB24_WEAPON_SHORTBOW</item>
+			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
+			<item>ID_WOTC_PHB24_ITEM_HEALERS_KIT</item>
+			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<element name="Background Equipment Pack (Wayfarer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BACKGROUND_EQUIPMENT_PACK_WAYFARER">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Wayfarer Background, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent">• Thieves' Tools</p>
+			<p class="indent">• Bedroll</p>
+			<p class="indent">• 2 Pouches</p>
+			<p class="indent">• Traveler's Clothes</p>
+			<p><b>Note:</b> This pack doesn't include the Gaming Set of the same kind as Proficiency gained from this Background (can be taken from "Tools" Equipment category) and 16 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_THIEVES_TOOLS</item>
+			<item>ID_WOTC_PHB24_ITEM_BEDROLL</item>
+			<item amount="2">ID_WOTC_PHB24_ITEM_POUCH</item>
+			<item>ID_WOTC_PHB24_ITEM_CLOTHES_TRAVELERS</item>
+		</extract>
+	</element>
+
+	<!-- Class Equipment Packs -->
+	<element name="Class Equipment Pack (Barbarian)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_BARBARIAN">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Barbarian Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Greataxe</p>
+			<p class="indent">• 4 Handaxes</p>
+			<p class="indent" style="margin-bottom:5px">• Explorer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include 15 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_GREATAXE</item>
+			<item amount="4">ID_WOTC_PHB24_WEAPON_HANDAXE</item>
+			<item>ID_WOTC_PHB24_ITEM_EXPLORERS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Bard)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_BARD">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Bard Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent" style="margin-bottom:5px">• Entertainer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Leather Armor, Musical Instrument of your choice (can be selected under "Musical Instrument" category) and 19 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_ENTERTAINERS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Cleric)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_CLERIC">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Cleric Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p> 
+			<p class="indent">• Mace</p>
+			<p class="indent" style="margin-bottom:5px">• Priest's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Chain Shirt, Shield, Holy Symbol (can be selected under "Spellcasting Focus" category) and 7 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_MACE</item>
+			<item>ID_WOTC_PHB24_ITEM_PRIESTS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Druid)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_DRUID">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Druid Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Sickle</p>
+			<p class="indent">• Druidic Focus (Quarterstaff)</p>
+			<p class="indent">• Explorer's Pack</p>
+			<p class="indent" style="margin-bottom:5px">• Herbalism kit</p>
+			<p><b>Note:</b> This pack doesn't include Leather Armor, Shield and 9 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SICKLE</item>
+			<item>ID_WOTC_PHB24_WEAPON_QUARTERSTAFF</item>
+			<item>ID_WOTC_PHB24_ITEM_EXPLORERS_PACK</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_HERBALISM_KIT</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Fighter, Option A)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_FIGHTER_1">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Fighter Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Greatsword</p>
+			<p class="indent">• Flail</p>
+			<p class="indent">• 8 Javelins</p>
+			<p class="indent" style="margin-bottom:5px">• Dungeoneer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Chain Mail and 4 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_GREATSWORD</item>
+			<item>ID_WOTC_PHB24_WEAPON_FLAIL</item>
+			<item amount="8">ID_WOTC_PHB24_WEAPON_JAVELIN</item>
+			<item>ID_WOTC_PHB24_ITEM_DUNGEONEERS_PACK</item>
+		</extract>
+	</element>
+	<element name="Class Equipment Pack (Fighter, Option B)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_FIGHTER_2">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Fighter Class, if you chose option B for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Scimitar</p>
+			<p class="indent">• Shortsword</p>
+			<p class="indent">• Longbow</p>
+			<p class="indent">• 20 Arrows</p>
+			<p class="indent">• Quiver</p>
+			<p class="indent" style="margin-bottom:5px">• Dungeoneer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Studded Leather Armor and 11 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SCIMITAR</item>
+			<item>ID_WOTC_PHB24_WEAPON_SHORTSWORD</item>
+			<item>ID_WOTC_PHB24_WEAPON_LONGBOW</item>
+			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
+			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
+			<item>ID_WOTC_PHB24_ITEM_DUNGEONEERS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Monk)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_MONK">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Monk Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Spear</p>
+			<p class="indent">• 5 Daggers</p>
+			<p class="indent" style="margin-bottom:5px">• Explorer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Artisan's Tools or Musical Instrument which was chosen for this Class's tool proficiency and 11 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SPEAR</item>
+			<item amount="5">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_EXPLORERS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Paladin)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_PALADIN">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Paladin Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Longsword</p>
+			<p class="indent">• 6 Javelins</p>
+			<p class="indent" style="margin-bottom:5px">• Priest's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Chain Mail, Shield, Holy Symbol (can be selected under "Spellcasting Focus" category) and 9 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_LONGSWORD</item>
+			<item amount="6">ID_WOTC_PHB24_WEAPON_JAVELIN</item>
+			<item>ID_WOTC_PHB24_ITEM_PRIESTS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Ranger)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_RANGER">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Ranger Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Scimitar</p>
+			<p class="indent">• Shortsword</p>
+			<p class="indent">• Longbow</p>
+			<p class="indent">• 20 Arrows</p>
+			<p class="indent">• Quiver</p>
+			<p class="indent">• Druidic Focus (sprig of mistletoe)</p>
+			<p class="indent" style="margin-bottom:5px">• Explorer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Studded Leather Armor and 7 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SCIMITAR</item>
+			<item>ID_WOTC_PHB24_WEAPON_SHORTSWORD</item>
+			<item>ID_WOTC_PHB24_WEAPON_LONGBOW</item>
+			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
+			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
+			<item>ID_WOTC_PHB24_ITEM_DRUIDIC_FOCUS_SPRIG_OF_MISTLETOE</item>
+			<item>ID_WOTC_PHB24_ITEM_EXPLORERS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Rogue)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_ROGUE">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Rogue Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent">• Shortsword</p>
+			<p class="indent">• Shortbow</p>
+			<p class="indent">• 20 Arrows</p>
+			<p class="indent">• Quiver</p>
+			<p class="indent">• Thieves' Tools</p>
+			<p class="indent" style="margin-bottom:5px">• Burglar's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Leather Armor and 8 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_WEAPON_SHORTSWORD</item>
+			<item>ID_WOTC_PHB24_WEAPON_SHORTBOW</item>
+			<item amount="20">ID_WOTC_PHB24_ITEM_ARROW</item>
+			<item>ID_WOTC_PHB24_ITEM_QUIVER</item>
+			<item>ID_WOTC_PHB24_ITEM_TOOL_THIEVES_TOOLS</item>
+			<item>ID_WOTC_PHB24_ITEM_BURGLARS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Sorcerer)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_SORCERER">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Sorcerer Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Spear</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent">• Arcane Focus (crystal)</p>
+			<p class="indent" style="margin-bottom:5px">• Dungeoneer's Pack</p>
+			<p><b>Note:</b> This pack doesn't include 28 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SPEAR</item>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_ARCANE_FOCUS_CRYSTAL</item>
+			<item>ID_WOTC_PHB24_ITEM_DUNGEONEERS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Warlock)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_WARLOCK">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Warlock Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• Sickle</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent">• Arcane Focus (orb)</p>
+			<p class="indent">• Book (occult lore)</p>
+			<p class="indent" style="margin-bottom:5px">• Scholar's Pack</p>
+			<p><b>Note:</b> This pack doesn't include Leather Armor and 15 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item>ID_WOTC_PHB24_WEAPON_SICKLE</item>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_ITEM_ARCANE_FOCUS_ORB</item>
+			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
+			<item>ID_WOTC_PHB24_ITEM_SCHOLARS_PACK</item>
+		</extract>
+	</element>
+
+	<element name="Class Equipment Pack (Wizard)" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_CLASS_EQUIPMENT_PACK_WIZARD">
+		<description>
+			<p style="margin-bottom:5px">This pack contains items that are given to a character of Wizard Class, if you chose option A for Equipment.</p>
+			<p>You will receive following items by extracting contents of this pack:</p>
+			<p class="indent">• 2 Daggers</p>
+			<p class="indent">• Arcane Focus (Quarterstaff)</p>
+			<p class="indent">• Robe</p>
+			<p class="indent">• Spellbook</p>
+			<p class="indent" style="margin-bottom:5px">• Scholar's Pack</p>
+			<p><b>Note:</b> This pack doesn't include 5 GP.</p>
+		</description>
+		<setters>
+			<set name="category">Equipment Packs</set>
+			<set name="cost">—</set>
+			<set name="weight">—</set>
+		</setters>
+		<extract>
+			<item amount="2">ID_WOTC_PHB24_WEAPON_DAGGER</item>
+			<item>ID_WOTC_PHB24_WEAPON_QUARTERSTAFF</item>
+			<item>ID_WOTC_PHB24_ITEM_ROBE</item>
+			<item>ID_WOTC_PHB24_ITEM_BOOK</item>
+			<item>ID_WOTC_PHB24_ITEM_SCHOLARS_PACK</item>
+		</extract>
+	</element>
+
+	<!-- Item Packs -->
 	<element name="Burglar's Pack" type="Item" source="Player’s Handbook (2024)" id="ID_WOTC_PHB24_ITEM_BURGLARS_PACK">
 		<description>
 			<p>A Burglar's Pack contains the following items: Backpack, Ball Bearings, Bell, 10 Candles, Crowbar, Hooded Lantern, 7 flasks of Oil, 5 days of Rations, Rope, Tinderbox, and Waterskin.</p>


### PR DESCRIPTION
• added Equipment Packs for Classes. Giving armor from these packs crashes an app, so their exclusion is mentioned in the notes.
• moved Background Packs from individual Backgrounds into Packs file.
• misc. change: changed Shield's ID to fit its type.