### PR TITLE
[PHB24] Hotfix №2

### DIFF
--- a/core/players-handbook-2024.index
+++ b/core/players-handbook-2024.index
@@ -4,7 +4,7 @@
 		<name>Player’s Handbook 2024</name>
 		<description></description>
 		<author url="">Wizards of the Coast</author>
-		<update version="0.0.2">
+		<update version="0.0.3">
 			<file name="players-handbook-2024.index" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024.index" />
 		</update>
 	</info>
@@ -24,6 +24,7 @@
 		<!-- classes -->
 		<file name="class-barbarian.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-barbarian.xml" />
 		<file name="class-bard.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-bard.xml" />
+		<obsolete name="class-cleric" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-cleric" />
 		<file name="class-cleric.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-cleric.xml" />
 		<file name="class-druid.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-druid.xml" />
 		<file name="class-fighter.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-fighter.xml" />

--- a/core/players-handbook-2024/backgrounds/background-artisan.xml
+++ b/core/players-handbook-2024/backgrounds/background-artisan.xml
@@ -4,7 +4,7 @@
 		<name>Artisan</name>
 		<description>Artisan background from the Player’s Handbook 2024.</description>
 		<author url="https://dndstore.wizards.com/us/en/product/1001494/2024-player-s-handbook-digital-plus-physical-bundle">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="background-artisan.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/backgrounds/background-artisan.xml" />
 		</update>
 	</info>
@@ -27,7 +27,7 @@
 			<set name="short">Strength, Dexterity, Intelligence, Crafter Feat, Investigation and Persuasion Skills, an Artisan's Tool</set>
 		</setters>
 		<rules>
-			<grant type="Ability Score Improvement" id="ID_WOTC_INTERNAL_ABILITY_SCORE_IMPROVEMENT_COMBINATION_STR_DEX_INT" />
+			<grant type="Ability Score Improvement" id="ID_INTERNAL_ABILITY_SCORE_IMPROVEMENT_COMBINATION_STR_DEX_INT" />
 			<grant type="Feat" id="ID_WOTC_PHB24_FEAT_CRAFTER" />
 			<grant type="Proficiency" id="ID_PROFICIENCY_SKILL_INVESTIGATION" />
 			<grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERSUASION" />

--- a/core/players-handbook/eldritch-invocations.xml
+++ b/core/players-handbook/eldritch-invocations.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name></name>
-		<update version="0.0.2">
+		<update version="0.0.3">
 			<file name="eldritch-invocations.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook/eldritch-invocations.xml" />
 		</update>
 	</info>
@@ -195,7 +195,8 @@
 		</rules>
 	</element>
 
-	<element name="Eldritch Spear" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_PHB_CLASS_FEATURE_ELDRITCH_INVOCATION_ELDRITCH_SPEAR">
+	<element name="Eldritch Spear" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_PHB_CLASS_FEATURE_ELDRITCH_INVOCATION_Eldritch_Spear">
+		<!-- ID is wrong, but it can't be fixed without breaking characters. Changing this ID to uppercase also leads to an issue of app creating a duplicate of this element in SRD source -->
 		<supports>Eldritch Invocation</supports>
 		<requirements>ID_PHB_SPELL_ELDRITCH_BLAST,!ID_WOTC_PHB24_CLASS_FEATURE_ELDRITCH_INVOCATION_ELDRITCH_SPEAR</requirements>
 		<prerequisite>eldritch blast cantrip</prerequisite>


### PR DESCRIPTION
• fixed wrong ID in Artisan Background.
• reverted change to the ID of PHB Eldritch Spear, to block the appearance of SRD source and not to break characters. Also added a comment for future reference.