### PR TITLE
[PHB24, Internal] Weapon Mastery grant and Additional Features

### DIFF
--- a/core/internal.xml
+++ b/core/internal.xml
@@ -2548,12 +2548,15 @@
 	<element name="Weapon Mastery Feature" type="Grants" source="Internal" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
 
 	<!--Weapon Mastery Additional Features-->
-	<element name="Weapon Mastery Feature" type="Item" source="Internal" id="ID_INTERNAL_ADDITIONAL_FEATURE_WEAPON_MASTERY_FEATURE">
+	<element name="Weapon Mastery Feature" type="Item" source="Internal" id="ID_INTERNAL_ITEM_WEAPON_MASTERY_FEATURE">
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
-			<p><b>Note:</b> This Additional Feature is intended for those playing a class made for the 2014 ruleset to gain Weapon Masteries at DM discretion. The primary reason for this would be bringing certain classes that may never be updated (i.e. Blood Hunter) up to the same playing field as 5.5e classes. The feature provided is adapted from the Weapon Mastery class feature present within the descriptions of the Paladin and Ranger classes in the <i>Player's Handbook (2024)</i>.</p>
-			<p>Your training with weapons allows you to use the mastery properties of two kinds of weapons of your choice with which you have proficiency, such as Longbows and Shortswords.</p>
-			<p class="indent">Whenever you finish a Long Rest, you can change the kinds of weapons you chose. For example, you could switch to using the mastery properties of Scimitars and Longswords.</p>
+			<p>You gain Weapon Mastery Class Feature.</p>
+			<p><b>Note:</b> This item is intended only for characters that <u>don't</u> have Weapon Mastery feature already (e.g. Monk Class characters). For ability to select more options search for <i>Additional Weapon Mastery</i> item.</p>
+			<p class="indent">Selection for Mastery appears under the <u>CLASS</u> sub-menu.</p>
+			<div class="reference">
+				<div element="ID_INTERNAL_CLASS_FEATURE_WEAPON_MASTERY" />
+			</div>
 		</description>
 		<setters>
 			<set name="category">Additional Feature</set>
@@ -2581,10 +2584,12 @@
 	</element>
 
 	<!--Weapon Mastery Selection-->
-	<element name="Weapon Mastery Selection" type="Item" source="Internal" id="ID_INTERNAL_ADDITIONAL_FEATURE_WEAPON_MASTERY_SELECTION">
+	<element name="Weapon Mastery Selection" type="Item" source="Internal" id="ID_INTERNAL_ITEM_WEAPON_MASTERY_SELECTION">
 		<description>
 			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
 			<p>You gain an extra Weapon Mastery of your choice.</p>
+			<p><b>Note:</b> This item is intended only for characters that <u>already have</u> Weapon Mastery feature (e.g. Fighter Class characters). For ability to gain the Class feature itself search for <i>Weapon Mastery Feature</i> item.</p>
+			<p class="indent">Selection for Mastery appears under the <u>CLASS</u> sub-menu.</p>
 		</description>
 		<setters>
 			<set name="category">Additional Feature</set>

--- a/core/internal.xml
+++ b/core/internal.xml
@@ -3,7 +3,7 @@
 	<info>
 		<name>Internal</name>
 		<description>Elements that should've been part of the app itself</description>
-		<update version="0.1.7">
+		<update version="0.1.8">
 			<file name="internal.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/internal.xml" />
 		</update>
 	</info>
@@ -2541,6 +2541,58 @@
 			<stat name="intelligence" value="1" alt="Ability Score Increase (Background)" />
 			<stat name="wisdom" value="1" alt="Ability Score Increase (Background)" />
 			<stat name="charisma" value="1" alt="Ability Score Increase (Background)" />
+		</rules>
+	</element>
+
+	<!--Weapon Mastery Feature Grant-->
+	<element name="Weapon Mastery Feature" type="Grants" source="Internal" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
+
+	<!--Weapon Mastery Additional Features-->
+	<element name="Weapon Mastery Feature" type="Item" source="Internal" id="ID_INTERNAL_ADDITIONAL_FEATURE_WEAPON_MASTERY_FEATURE">
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<p><b>Note:</b> This Additional Feature is intended for those playing a class made for the 2014 ruleset to gain Weapon Masteries at DM discretion. The primary reason for this would be bringing certain classes that may never be updated (i.e. Blood Hunter) up to the same playing field as 5.5e classes. The feature provided is adapted from the Weapon Mastery class feature present within the descriptions of the Paladin and Ranger classes in the <i>Player's Handbook (2024)</i>.</p>
+			<p>Your training with weapons allows you to use the mastery properties of two kinds of weapons of your choice with which you have proficiency, such as Longbows and Shortswords.</p>
+			<p class="indent">Whenever you finish a Long Rest, you can change the kinds of weapons you chose. For example, you could switch to using the mastery properties of Scimitars and Longswords.</p>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<grant type="Class Feature" id="ID_INTERNAL_CLASS_FEATURE_WEAPON_MASTERY" />
+		</rules>
+	</element>
+	
+	<element name="Weapon Mastery" type="Class Feature" source="Internal" id="ID_INTERNAL_CLASS_FEATURE_WEAPON_MASTERY">
+		<compendium display="false" />
+		<description>
+			<p>Your training with weapons allows you to use the mastery properties of two kinds of weapons of your choice with which you have proficiency, such as Longbows and Shortswords.</p>
+			<p class="indent">Whenever you finish a Long Rest, you can change the kinds of weapons you chose. For example, you could switch to using the mastery properties of Scimitars and Longswords.</p>
+		</description>
+		<sheet alt="Weapon Mastery">
+			<description>Whenever you finish a Long Rest, you can change one of the weapons you previously chosen for a different one.</description>
+		</sheet>
+		<rules>
+			<grant type="Grants" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
+			<select type="Class Feature" name="Weapon Mastery" supports="Weapon Mastery" number="2" />
+		</rules>
+	</element>
+
+	<!--Weapon Mastery Selection-->
+	<element name="Weapon Mastery Selection" type="Item" source="Internal" id="ID_INTERNAL_ADDITIONAL_FEATURE_WEAPON_MASTERY_SELECTION">
+		<description>
+			<p><i>You can equip this item to “enable” it. It remains hidden from the inventory on your character sheet.</i></p>
+			<p>You gain an extra Weapon Mastery of your choice.</p>
+		</description>
+		<setters>
+			<set name="category">Additional Feature</set>
+			<set name="slot">misc</set>
+			<set name="inventory-hidden">true</set>
+		</setters>
+		<rules>
+			<select type="Class Feature" name="Weapon Mastery" supports="Weapon Mastery" />
 		</rules>
 	</element>
 </elements>

--- a/core/players-handbook-2024/classes/class-barbarian.xml
+++ b/core/players-handbook-2024/classes/class-barbarian.xml
@@ -4,7 +4,7 @@
 		<name>Barbarian</name>
 		<description>The Barbarian class from the Player’s Handbook 2024.</description>
 		<author url="https://dndstore.wizards.com/us/en/product/1001494/2024-player-s-handbook-digital-plus-physical-bundle">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="class-barbarian.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-barbarian.xml" />
 		</update>
 	</info>
@@ -199,6 +199,7 @@
 			<description>Whenever you finish a Long Rest, you can change one of the weapon masteries you have to a different one.</description>
 		</sheet>
 		<rules>
+			<grant type="Grants" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
 			<select type="Class Feature" name="Weapon Mastery (Barbarian 1)" supports="Weapon Mastery" number="2"/>
 			<select type="Class Feature" name="Weapon Mastery (Barbarian 4)" supports="Weapon Mastery" level="4"/>
 			<select type="Class Feature" name="Weapon Mastery (Barbarian 10)" supports="Weapon Mastery" level="10"/>

--- a/core/players-handbook-2024/classes/class-fighter.xml
+++ b/core/players-handbook-2024/classes/class-fighter.xml
@@ -4,7 +4,7 @@
 		<name>Fighter</name>
 		<description>The Fighter class from the Player’s Handbook 2024.</description>
 		<author url="https://dndstore.wizards.com/us/en/product/1001494/2024-player-s-handbook-digital-plus-physical-bundle">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="class-fighter.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-fighter.xml" />
 		</update>
 	</info>
@@ -167,6 +167,7 @@
 			<description>Whenever you finish a Long Rest, you can change one of the weapons you previously chosen for a different one. </description>
 		</sheet>
 		<rules>
+			<grant type="Grants" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
 			<select type="Class Feature" name="Weapon Mastery (Fighter 1)" level="1" supports="Weapon Mastery" number="3"/>
 			<select type="Class Feature" name="Weapon Mastery (Fighter 4)" level="4" supports="Weapon Mastery" />
 			<select type="Class Feature" name="Weapon Mastery (Fighter 10)" level="10" supports="Weapon Mastery" />

--- a/core/players-handbook-2024/classes/class-paladin.xml
+++ b/core/players-handbook-2024/classes/class-paladin.xml
@@ -4,7 +4,7 @@
 		<name>Paladin</name>
 		<description>The Paladin class from the Player’s Handbook 2024.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="class-paladin.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-paladin.xml" />
 		</update>
 	</info>
@@ -217,6 +217,7 @@
 			<description>Whenever you finish a Long Rest, you can change one of the weapons you previously chosen for a different one.</description>
 		</sheet>
 		<rules>
+			<grant type="Grants" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
 			<select type="Class Feature" name="Weapon Mastery" supports="Weapon Mastery" number="2"/>
 		</rules>
 	</element>

--- a/core/players-handbook-2024/classes/class-ranger.xml
+++ b/core/players-handbook-2024/classes/class-ranger.xml
@@ -4,7 +4,7 @@
 		<name>Ranger</name>
 		<description>The Ranger class from the Player’s Handbook 2024.</description>
 		<author url="https://dndstore.wizards.com/us/en/product/1001494/2024-player-s-handbook-digital-plus-physical-bundle">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="class-ranger.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-ranger.xml" />
 		</update>
 	</info>
@@ -214,6 +214,7 @@
 			<description>Whenever you finish a Long Rest, you can change one of the weapons you previously chosen for a different one.</description>
 		</sheet>
 		<rules>
+			<grant type="Grants" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
 			<select type="Class Feature" name="Weapon Mastery" supports="Weapon Mastery" number="2"/>
 		</rules>
 	</element>

--- a/core/players-handbook-2024/classes/class-rogue.xml
+++ b/core/players-handbook-2024/classes/class-rogue.xml
@@ -4,7 +4,7 @@
 		<name>Rogue</name>
 		<description>The Rogue class from the Player’s Handbook 2024.</description>
 		<author url="https://dndstore.wizards.com/us/en/product/1001494/2024-player-s-handbook-digital-plus-physical-bundle">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="class-rogue.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/classes/class-rogue.xml" />
 		</update>
 	</info>
@@ -195,6 +195,7 @@
 			<description>Whenever you finish a Long Rest, you can change one of the weapon masteries you have to a different one.</description>
 		</sheet>
 		<rules>
+			<grant type="Grants" id="ID_INTERNAL_GRANTS_WEAPON_MASTERY_FEATURE" />
 			<select type="Class Feature" name="Weapon Mastery (Rogue 1)" supports="Weapon Mastery" number="2"/>
 		</rules>
 	</element>


### PR DESCRIPTION
This adds a Weapon Mastery grant to each class's "Weapon Mastery" feature. Recent Unearthed Arcana documents have had Feats that required the Weapon Mastery feature, similar to how some Feats require the Spellcasting or Pact Magic feature.

I also added two Additional Features. One is a select to add one additional Weapon Mastery to a character. The other is a grant to give the Weapon Mastery class feature, mainly to be used for classes made for the 2014 rules to be brought up to 5.5e.