### PR TITLE
[PHB24] Wood Elf Speed fix

### DIFF
--- a/core/players-handbook-2024/races/race-elf.xml
+++ b/core/players-handbook-2024/races/race-elf.xml
@@ -4,7 +4,7 @@
 		<name>Elf</name>
 		<description>The Elf species from the Player’s Handbook 2024.</description>
 		<author url="https://dndstore.wizards.com/us/en/product/1001494/2024-player-s-handbook-digital-plus-physical-bundle">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="race-elf.xml" url="https://raw.githubusercontent.com/AuroraLegacy/elements/master/core/players-handbook-2024/races/race-elf.xml" />
 		</update>
 	</info>
@@ -218,7 +218,7 @@
 		<sheet display="false" />
 		<rules>
 			<grant type="Grants" id="ID_INTERNAL_GRANT_RACE_WOOD_ELF" />
-			<stat name="speed" value="35" bonus="base" />
+			<stat name="innate speed" value="35" bonus="base" />
 			<select type="Racial Trait" name="Spellcasting Ability (Elven Lineage)" supports="ID_WOTC_PHB24_RACIAL_TRAIT_ELF_ELVEN_LINEAGE_WOOD_ELF_INTELLIGENCE|ID_WOTC_PHB24_RACIAL_TRAIT_ELF_ELVEN_LINEAGE_WOOD_ELF_WISDOM|ID_WOTC_PHB24_RACIAL_TRAIT_ELF_ELVEN_LINEAGE_WOOD_ELF_CHARISMA" />
 		</rules>
 	</element>


### PR DESCRIPTION
The Wood Elf's base Speed was using the ``speed`` stat instead of ``innate speed``. This fixes that.